### PR TITLE
Improve DVSPortal login compatibility and error diagnostics

### DIFF
--- a/src/pycityvisitorparking/client.py
+++ b/src/pycityvisitorparking/client.py
@@ -74,6 +74,7 @@ class Client:
         *,
         base_url: str | None = None,
         api_uri: str | None = None,
+        request_context: str | None = None,
     ) -> BaseProvider:
         _LOGGER.debug("Loading provider %s", provider_id)
         manifest, provider_cls = await asyncio.to_thread(_load_provider_data, provider_id)
@@ -84,7 +85,7 @@ class Client:
             manifest.favorite_update_fields,
             manifest.reservation_update_fields,
         )
-        return provider_cls(
+        provider = provider_cls(
             session,
             manifest,
             base_url=base_url if base_url is not None else self._base_url,
@@ -92,6 +93,8 @@ class Client:
             timeout=self._timeout,
             retry_count=self._retry_count,
         )
+        provider.set_request_context(request_context)
+        return provider
 
     def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None:

--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -550,7 +550,17 @@ class Provider(BaseProvider):
                 return await self._do_post_form(url, form_data)
             except AuthError:
                 if allow_reauth and attempt == 0:
-                    _LOGGER.warning("Provider %s reauth triggered", self.provider_id)
+                    context, target, package_version = self._request_log_details()
+                    _LOGGER.warning(
+                        (
+                            "Provider %s reauth triggered "
+                            "(context=%s, target=%s, package_version=%s)"
+                        ),
+                        self.provider_id,
+                        context,
+                        target,
+                        package_version,
+                    )
                     await self._reauthenticate()
                     continue
                 raise

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import datetime
-from typing import Any, Literal, TypeVar, overload
+from typing import Any, Literal, Protocol, TypeVar, overload
 from urllib.parse import urlparse
 
 import aiohttp
@@ -29,6 +29,12 @@ _LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
+class _HttpSession(Protocol):
+    """Minimal interface required from an HTTP session."""
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any: ...
+
+
 class BaseProvider(ABC):
     """Base class for provider implementations."""
 
@@ -37,7 +43,7 @@ class BaseProvider(ABC):
 
     def __init__(
         self,
-        session: aiohttp.ClientSession,
+        session: _HttpSession,
         manifest: ProviderManifest,
         *,
         base_url: str | None = None,

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -7,9 +7,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import datetime
 from typing import Any, Literal, TypeVar, overload
+from urllib.parse import urlparse
 
 import aiohttp
 
+from .._version import __version__ as PACKAGE_VERSION
 from ..exceptions import AuthError, NetworkError, ProviderError, ValidationError
 from ..models import Favorite, Permit, ProviderInfo, Reservation, ZoneValidityBlock
 from ..util import (
@@ -51,6 +53,36 @@ class BaseProvider(ABC):
         self._api_uri = self._normalize_api_uri(api_uri)
         self._timeout = timeout or _DEFAULT_TIMEOUT
         self._retry_count = max(0, retry_count)
+        self._request_context_name: str | None = None
+
+    def set_request_context(self, context_name: str | None) -> None:
+        """Set a human-readable context label for request diagnostics."""
+        if context_name is None:
+            self._request_context_name = None
+            return
+        value = context_name.strip()
+        self._request_context_name = value or None
+
+    def _request_target_label(self) -> str:
+        """Return a stable target label for diagnostics and logs."""
+        if self._base_url is None:
+            return "unknown"
+        parsed = urlparse(self._base_url)
+        return parsed.netloc or self._base_url
+
+    def _request_context_label(self) -> str:
+        """Return city/context label for diagnostics and logs."""
+        if self._request_context_name:
+            return self._request_context_name
+        return self._request_target_label()
+
+    def _request_log_details(self) -> tuple[str, str, str]:
+        """Return (context, target, package_version) for consistent error logging."""
+        return (
+            self._request_context_label(),
+            self._request_target_label(),
+            PACKAGE_VERSION,
+        )
 
     @property
     def provider_id(self) -> str:
@@ -252,9 +284,12 @@ class BaseProvider(ABC):
             except (aiohttp.ClientError, TimeoutError) as exc:
                 last_error = exc
                 _LOGGER.warning(
-                    "Provider %s request error: %s",
+                    ("Provider %s request error: %s (context=%s, target=%s, package_version=%s)"),
                     self.provider_id,
                     exc.__class__.__name__,
+                    self._request_context_label(),
+                    self._request_target_label(),
+                    PACKAGE_VERSION,
                 )
                 if attempt >= attempts - 1:
                     raise NetworkError("Network request failed.") from exc
@@ -300,9 +335,15 @@ class BaseProvider(ABC):
         if 200 <= response.status < 300:
             return
         _LOGGER.warning(
-            "Provider %s request failed with status %s",
+            (
+                "Provider %s request failed with status %s "
+                "(context=%s, target=%s, package_version=%s)"
+            ),
             self.provider_id,
             response.status,
+            self._request_context_label(),
+            self._request_target_label(),
+            PACKAGE_VERSION,
         )
         if response.status in (401, 403):
             raise AuthError("Authentication failed.")

--- a/src/pycityvisitorparking/provider/dvsportal/README.md
+++ b/src/pycityvisitorparking/provider/dvsportal/README.md
@@ -37,37 +37,38 @@ listed `base_url` and `api_uri` values:
 
 | Municipality          | base_url                                                                             | api_uri              |
 | --------------------- | ------------------------------------------------------------------------------------ | -------------------- |
-| Apeldoorn             | [https://parkeren.apeldoorn.nl](https://parkeren.apeldoorn.nl)                       | /DVSWebAPI/api |
+| Apeldoorn             | [https://parkeren.apeldoorn.nl](https://parkeren.apeldoorn.nl)                       | /DVSPortal/api |
 | Bloemendaal           | [https://parkeren.bloemendaal.nl](https://parkeren.bloemendaal.nl)                   | /DVSWebAPI/api |
 | Delft                 | [https://vergunningen.parkerendelft.com](https://vergunningen.parkerendelft.com)     | /DVSWebAPI/api |
-| Den Bosch             | [https://parkeren.s-hertogenbosch.nl](https://parkeren.s-hertogenbosch.nl)           | /DVSWebAPI/api |
+| Den Bosch             | [https://parkeren.s-hertogenbosch.nl](https://parkeren.s-hertogenbosch.nl)           | /DVSPortal/api |
 | Doetinchem (via Buha) | [https://parkeren.buha.nl](https://parkeren.buha.nl)                                 | /DVSWebAPI/api |
-| Groningen             | [https://aanvraagparkeren.groningen.nl](https://aanvraagparkeren.groningen.nl)       | /DVSWebAPI/api |
+| Groningen             | [https://aanvraagparkeren.groningen.nl](https://aanvraagparkeren.groningen.nl)       | /DVSPortal/api |
 | Haarlem               | [https://parkeren.haarlem.nl](https://parkeren.haarlem.nl)                           | /DVSWebAPI/api |
 | Harlingen             | [https://parkeervergunningen.harlingen.nl](https://parkeervergunningen.harlingen.nl) | /DVSWebAPI/api |
 | Heemstede             | [https://parkeren.heemstede.nl](https://parkeren.heemstede.nl)                       | /DVSWebAPI/api |
 | Heerenveen            | [https://parkeren.heerenveen.nl](https://parkeren.heerenveen.nl)                     | /DVSWebAPI/api |
-| Heerlen               | [https://parkeren.heerlen.nl](https://parkeren.heerlen.nl)                           | /DVSWebAPI/api |
+| Heerlen               | [https://parkeren.heerlen.nl](https://parkeren.heerlen.nl)                           | /DVSPortal/api |
 | Hengelo               | [https://parkeren.hengelo.nl](https://parkeren.hengelo.nl)                           | /DVSWebAPI/api |
 | Katwijk               | [https://parkeren.katwijk.nl](https://parkeren.katwijk.nl)                           | /DVSWebAPI/api |
 | Leiden                | [https://parkeren.leiden.nl](https://parkeren.leiden.nl)                             | /DVSWebAPI/api |
-| Leidschendam-Voorburg | [https://parkeren.lv.nl](https://parkeren.lv.nl)                                     | /DVSWebAPI/api |
+| Leidschendam-Voorburg | [https://parkeren.lv.nl](https://parkeren.lv.nl)                                     | /DVSPortal/api |
 | Middelburg            | [https://parkeren.middelburg.nl](https://parkeren.middelburg.nl)                     | /DVSWebAPI/api |
+| Nijmegen              | [https://parkeerproducten.nijmegen.nl](https://parkeerproducten.nijmegen.nl)         | /DVSPortal/api |
 | Nissewaard            | [https://parkeren.nissewaard.nl](https://parkeren.nissewaard.nl)                     | /DVSWebAPI/api |
 | Oldenzaal             | [https://parkeren.oldenzaal.nl](https://parkeren.oldenzaal.nl)                       | /DVSWebAPI/api |
 | Rijswijk              | [https://parkeren.rijswijk.nl](https://parkeren.rijswijk.nl)                         | /DVSWebAPI/api |
 | Roermond              | [https://parkeren.roermond.nl](https://parkeren.roermond.nl)                         | /DVSWebAPI/api |
 | Schouwen-Duiveland    | [https://parkeren.schouwen-duiveland.nl](https://parkeren.schouwen-duiveland.nl)     | /DVSWebAPI/api |
-| Sittard-Geleen        | [https://parkeren.sittard-geleen.nl](https://parkeren.sittard-geleen.nl)             | /DVSWebAPI/api |
-| Smallingerland        | [https://parkeren.smallingerland.nl](https://parkeren.smallingerland.nl)             | /DVSWebAPI/api |
+| Sittard-Geleen        | [https://parkeren.sittard-geleen.nl](https://parkeren.sittard-geleen.nl)             | /DVSPortal/api |
+| Smallingerland        | [https://parkeren.smallingerland.nl](https://parkeren.smallingerland.nl)             | /DVSPortal/api |
 | Súdwest-Fryslân       | [https://parkeren.sudwestfryslan.nl](https://parkeren.sudwestfryslan.nl)             | /DVSWebAPI/api |
 | Veere                 | [https://parkeren.veere.nl](https://parkeren.veere.nl)                               | /DVSWebAPI/api |
 | Venlo                 | [https://parkeren.venlo.nl](https://parkeren.venlo.nl)                               | /DVSWebAPI/api |
-| Vlissingen            | [https://parkeren.vlissingen.nl](https://parkeren.vlissingen.nl)                     | /DVSWebAPI/api |
-| Waadhoeke             | [https://parkeren.waadhoeke.nl](https://parkeren.waadhoeke.nl)                       | /DVSWebAPI/api |
+| Vlissingen            | [https://parkeren.vlissingen.nl](https://parkeren.vlissingen.nl)                     | /DVSPortal/api |
+| Waadhoeke             | [https://parkeren.waadhoeke.nl](https://parkeren.waadhoeke.nl)                       | /DVSPortal/api |
 | Waalwijk              | [https://parkeren.waalwijk.nl](https://parkeren.waalwijk.nl)                         | /DVSWebAPI/api |
-| Weert                 | [https://parkeerloket.weert.nl](https://parkeerloket.weert.nl)                       | /DVSWebAPI/api |
-| Zaanstad              | [https://parkeren.zaanstad.nl](https://parkeren.zaanstad.nl)                         | /DVSWebAPI/api |
+| Weert                 | [https://parkeerloket.weert.nl](https://parkeerloket.weert.nl)                       | /DVSPortal/api |
+| Zaanstad              | [https://parkeren.zaanstad.nl](https://parkeren.zaanstad.nl)                         | /DVSPortal/api |
 | Zevenaar              | [https://parkeren.zevenaar.nl](https://parkeren.zevenaar.nl)                         | /DVSWebAPI/api |
 | Zutphen               | [https://parkeren.zutphen.nl](https://parkeren.zutphen.nl)                           | /DVSWebAPI/api |
 | Zwolle                | [https://parkeerloket.zwolle.nl](https://parkeerloket.zwolle.nl)                     | /DVSWebAPI/api |

--- a/src/pycityvisitorparking/provider/dvsportal/api.py
+++ b/src/pycityvisitorparking/provider/dvsportal/api.py
@@ -96,7 +96,11 @@ class Provider(BaseProvider):
                 try:
                     login_method_int = int(raw_lm)
                 except ValueError, TypeError:
-                    pass
+                    _LOGGER.debug(
+                        "Provider %s received invalid login_method_int=%r; using fallback.",
+                        self.provider_id,
+                        raw_lm,
+                    )
             if permit_media_type_id is None:
                 permit_media_type_id = self._permit_media_type_id
             if login_method_int is None:
@@ -520,7 +524,12 @@ class Provider(BaseProvider):
             try:
                 login_method_int = methods.index(LOGIN_METHOD_PAS) + 1
             except ValueError:
-                pass
+                _LOGGER.debug(
+                    "Provider %s login methods did not include %r; using fallback index %s.",
+                    self.provider_id,
+                    LOGIN_METHOD_PAS,
+                    login_method_int,
+                )
         return permit_media_type_id, login_method_int
 
     async def _fetch_permit_media_type_id(self) -> str | int:

--- a/src/pycityvisitorparking/provider/dvsportal/api.py
+++ b/src/pycityvisitorparking/provider/dvsportal/api.py
@@ -66,6 +66,7 @@ class Provider(BaseProvider):
         self._auth_header_value: str | None = None
         self._credentials: dict[str, str] | None = None
         self._permit_media_type_id: str | int | None = None
+        self._login_method_int: int | None = None
         self._permit_media_code: str | None = None
         self._api_timezone: ZoneInfo | None = None
         self._operation_lock = asyncio.Lock()
@@ -79,29 +80,62 @@ class Provider(BaseProvider):
             merged = self._merge_credentials(credentials, **kwargs)
             username = merged.get("username")
             password = merged.get("password")
-            permit_media_type_id = merged.get("permit_media_type_id")
             if not username:
                 raise ValidationError("username is required.")
             if not password:
                 raise ValidationError("password is required.")
+
+            # Prefer the minimal login payload first.
+            # Several DVSPortal deployments return HTTP 500 for the extended
+            # login shape or for GET /login config probing, while minimal login
+            # remains functional.
+            permit_media_type_id: str | int | None = merged.get("permit_media_type_id")
+            login_method_int: int | None = None
+            raw_lm = merged.get("login_method_int")
+            if raw_lm is not None:
+                try:
+                    login_method_int = int(raw_lm)
+                except ValueError, TypeError:
+                    pass
             if permit_media_type_id is None:
                 permit_media_type_id = self._permit_media_type_id
-            if permit_media_type_id is None:
-                permit_media_type_id = await self._fetch_permit_media_type_id()
-            self._validate_media_type_id(permit_media_type_id)
+            if login_method_int is None:
+                login_method_int = self._login_method_int
 
             payload = {
-                "identifier": username,
-                "loginMethod": LOGIN_METHOD_PAS,
-                "password": password,
-                "permitMediaTypeID": permit_media_type_id,
+                "Identifier": username,
+                "Password": password,
             }
-            data = await self._request_json(
-                "POST",
-                LOGIN_ENDPOINT,
-                json=payload,
-                allow_reauth=False,
-            )
+            try:
+                data = await self._request_json(
+                    "POST",
+                    LOGIN_ENDPOINT,
+                    json=payload,
+                    allow_reauth=False,
+                )
+            except ProviderError as err:
+                # Fallback to extended payload when minimal model is rejected.
+                if "status 400" not in str(err) and "status 500" not in str(err):
+                    raise
+                if permit_media_type_id is None or login_method_int is None:
+                    fetched_id, fetched_method = await self._fetch_login_config()
+                    if permit_media_type_id is None:
+                        permit_media_type_id = fetched_id
+                    if login_method_int is None:
+                        login_method_int = fetched_method
+                self._validate_media_type_id(permit_media_type_id)
+                fallback_payload = {
+                    "Identifier": username,
+                    "LoginMethod": login_method_int,
+                    "Password": password,
+                    "PermitMediaTypeID": permit_media_type_id,
+                }
+                data = await self._request_json(
+                    "POST",
+                    LOGIN_ENDPOINT,
+                    json=fallback_payload,
+                    allow_reauth=False,
+                )
 
             status_value = data.get("LoginStatus")
             if isinstance(status_value, str) and status_value.isdigit():
@@ -112,12 +146,18 @@ class Provider(BaseProvider):
 
             self._token = str(token)
             self._auth_header_value = self._build_auth_header(self._token)
-            self._permit_media_type_id = permit_media_type_id
+            if permit_media_type_id is not None:
+                self._permit_media_type_id = permit_media_type_id
+            if login_method_int is not None:
+                self._login_method_int = login_method_int
             self._credentials = {
                 "username": username,
                 "password": password,
-                "permit_media_type_id": str(permit_media_type_id),
             }
+            if permit_media_type_id is not None:
+                self._credentials["permit_media_type_id"] = str(permit_media_type_id)
+            if login_method_int is not None:
+                self._credentials["login_method_int"] = str(login_method_int)
             _LOGGER.debug("Provider %s login completed", self.provider_id)
 
     async def get_permit(self) -> Permit:
@@ -184,9 +224,16 @@ class Provider(BaseProvider):
             try:
                 permit = self._extract_permit(data)
             except ProviderError:
+                context, target, package_version = self._request_log_details()
                 _LOGGER.warning(
-                    "Provider %s reservation create missing permit, refetching",
+                    (
+                        "Provider %s reservation create missing permit, refetching "
+                        "(context=%s, target=%s, package_version=%s)"
+                    ),
                     self.provider_id,
+                    context,
+                    target,
+                    package_version,
                 )
                 permit = await self._fetch_base()
             self._cache_defaults(permit)
@@ -264,9 +311,16 @@ class Provider(BaseProvider):
         try:
             permit = self._extract_permit(data)
         except ProviderError:
+            context, target, package_version = self._request_log_details()
             _LOGGER.warning(
-                "Provider %s reservation update missing permit, refetching",
+                (
+                    "Provider %s reservation update missing permit, refetching "
+                    "(context=%s, target=%s, package_version=%s)"
+                ),
                 self.provider_id,
+                context,
+                target,
+                package_version,
             )
             permit = await self._fetch_base()
         self._cache_defaults(permit)
@@ -316,9 +370,16 @@ class Provider(BaseProvider):
         try:
             permit = self._extract_permit(data)
         except ProviderError:
+            context, target, package_version = self._request_log_details()
             _LOGGER.warning(
-                "Provider %s reservation end missing permit, refetching",
+                (
+                    "Provider %s reservation end missing permit, refetching "
+                    "(context=%s, target=%s, package_version=%s)"
+                ),
                 self.provider_id,
+                context,
+                target,
+                package_version,
             )
             permit = await self._fetch_base()
         self._cache_defaults(permit)
@@ -382,9 +443,16 @@ class Provider(BaseProvider):
         try:
             permit = self._extract_permit(data)
         except ProviderError:
+            context, target, package_version = self._request_log_details()
             _LOGGER.warning(
-                "Provider %s favorite upsert missing permit, refetching list",
+                (
+                    "Provider %s favorite upsert missing permit, refetching list "
+                    "(context=%s, target=%s, package_version=%s)"
+                ),
                 self.provider_id,
+                context,
+                target,
+                package_version,
             )
             favorites = await self.list_favorites()
         else:
@@ -431,7 +499,8 @@ class Provider(BaseProvider):
             await self._request_json_auth("POST", FAVORITE_REMOVE_ENDPOINT, json=payload)
             _LOGGER.debug("Provider %s remove_favorite completed", self.provider_id)
 
-    async def _fetch_permit_media_type_id(self) -> str | int:
+    async def _fetch_login_config(self) -> tuple[str | int, int]:
+        """Fetch permit media type ID and login method integer from the server."""
         data = await self._request_json(
             "GET",
             LOGIN_ENDPOINT,
@@ -443,7 +512,21 @@ class Provider(BaseProvider):
         first = types[0]
         if not isinstance(first, dict) or "ID" not in first:
             raise ProviderError("Provider did not return a permit media type ID.")
-        return first["ID"]
+        permit_media_type_id = first["ID"]
+
+        methods = data.get("LoginMethods")
+        login_method_int = 2  # fallback: "Pas" is typically at 1-based index 2
+        if isinstance(methods, list):
+            try:
+                login_method_int = methods.index(LOGIN_METHOD_PAS) + 1
+            except ValueError:
+                pass
+        return permit_media_type_id, login_method_int
+
+    async def _fetch_permit_media_type_id(self) -> str | int:
+        """Backward-compatible helper for callers expecting only the media type ID."""
+        permit_media_type_id, _ = await self._fetch_login_config()
+        return permit_media_type_id
 
     async def _fetch_base(self) -> dict[str, Any]:
         await self._ensure_authenticated()
@@ -733,7 +816,17 @@ class Provider(BaseProvider):
                 )
             except AuthError:
                 if allow_reauth and attempt == 0:
-                    _LOGGER.warning("Provider %s reauth triggered", self.provider_id)
+                    context, target, package_version = self._request_log_details()
+                    _LOGGER.warning(
+                        (
+                            "Provider %s reauth triggered "
+                            "(context=%s, target=%s, package_version=%s)"
+                        ),
+                        self.provider_id,
+                        context,
+                        target,
+                        package_version,
+                    )
                     await self._reauthenticate()
                     request_headers = {
                         **DEFAULT_HEADERS,
@@ -762,17 +855,31 @@ class Provider(BaseProvider):
                 await self._handle_rate_limit(response, method, attempt, attempts)
                 raise self._RetryRequest()
             if response.status in (401, 403):
+                context, target, package_version = self._request_log_details()
                 _LOGGER.warning(
-                    "Provider %s request failed with auth status=%s",
+                    (
+                        "Provider %s request failed with auth status=%s "
+                        "(context=%s, target=%s, package_version=%s)"
+                    ),
                     self.provider_id,
                     response.status,
+                    context,
+                    target,
+                    package_version,
                 )
                 raise AuthError("Authentication failed.")
             if not 200 <= response.status < 300:
+                context, target, package_version = self._request_log_details()
                 _LOGGER.warning(
-                    "Provider %s request failed with status=%s",
+                    (
+                        "Provider %s request failed with status=%s "
+                        "(context=%s, target=%s, package_version=%s)"
+                    ),
                     self.provider_id,
                     response.status,
+                    context,
+                    target,
+                    package_version,
                 )
                 raise ProviderError(f"Provider request failed with status {response.status}.")
             if expect_json:

--- a/src/pycityvisitorparking/provider/dvsportal/tests/test_mapping.py
+++ b/src/pycityvisitorparking/provider/dvsportal/tests/test_mapping.py
@@ -308,6 +308,89 @@ async def test_login_requires_username():
 
 
 @pytest.mark.asyncio
+async def test_login_payload_uses_minimal_pascal_case_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with aiohttp.ClientSession() as session:
+        provider = Provider(
+            session,
+            ProviderManifest(
+                id="dvsportal",
+                name="DVS Portal",
+                favorite_update_fields=(),
+                reservation_update_fields=("end_time",),
+            ),
+            base_url="https://example",
+        )
+        captured: dict[str, Any] = {}
+
+        async def _fake_fetch_login_config() -> tuple[int, int]:
+            return (1, 2)
+
+        async def _fake_request_json(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = kwargs.get("json")
+            return {"LoginStatus": 1, "Token": "token"}
+
+        monkeypatch.setattr(provider, "_fetch_login_config", _fake_fetch_login_config)
+        monkeypatch.setattr(provider, "_request_json", _fake_request_json)
+
+        await provider.login(credentials={"username": "user-123", "password": "secret"})
+
+    payload = captured["json"]
+    assert captured["method"] == "POST"
+    assert captured["path"] == LOGIN_ENDPOINT
+    assert payload["Identifier"] == "user-123"
+    assert payload["Password"] == "secret"
+    assert "LoginMethod" not in payload
+    assert "PermitMediaTypeID" not in payload
+
+
+@pytest.mark.asyncio
+async def test_login_retries_with_minimal_payload_on_http_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with aiohttp.ClientSession() as session:
+        provider = Provider(
+            session,
+            ProviderManifest(
+                id="dvsportal",
+                name="DVS Portal",
+                favorite_update_fields=(),
+                reservation_update_fields=("end_time",),
+            ),
+            base_url="https://example",
+        )
+        calls: list[dict[str, Any]] = []
+
+        async def _fake_fetch_login_config() -> tuple[int, int]:
+            return (1, 2)
+
+        async def _fake_request_json(_method: str, _path: str, **kwargs: Any) -> dict[str, Any]:
+            payload = kwargs.get("json")
+            if not isinstance(payload, dict):
+                raise AssertionError("Expected JSON payload dictionary.")
+            calls.append(payload)
+            if len(calls) == 1:
+                raise ProviderError("Provider request failed with status 400.")
+            return {"LoginStatus": 1, "Token": "token"}
+
+        monkeypatch.setattr(provider, "_fetch_login_config", _fake_fetch_login_config)
+        monkeypatch.setattr(provider, "_request_json", _fake_request_json)
+
+        await provider.login(credentials={"username": "user-123", "password": "secret"})
+
+    assert calls[0] == {"Identifier": "user-123", "Password": "secret"}
+    assert calls[1] == {
+        "Identifier": "user-123",
+        "LoginMethod": 2,
+        "Password": "secret",
+        "PermitMediaTypeID": 1,
+    }
+
+
+@pytest.mark.asyncio
 async def test_default_api_uri_is_applied():
     async with aiohttp.ClientSession() as session:
         provider = Provider(

--- a/src/pycityvisitorparking/provider/the_hague/api.py
+++ b/src/pycityvisitorparking/provider/the_hague/api.py
@@ -497,7 +497,17 @@ class Provider(BaseProvider):
                 )
             except AuthError:
                 if allow_reauth and attempt == 0:
-                    _LOGGER.warning("Provider %s reauth triggered", self.provider_id)
+                    context, target, package_version = self._request_log_details()
+                    _LOGGER.warning(
+                        (
+                            "Provider %s reauth triggered "
+                            "(context=%s, target=%s, package_version=%s)"
+                        ),
+                        self.provider_id,
+                        context,
+                        target,
+                        package_version,
+                    )
                     await self._reauthenticate()
                     headers = self._build_headers()
                     request_kwargs["headers"] = headers

--- a/tests/test_base_provider.py
+++ b/tests/test_base_provider.py
@@ -55,6 +55,7 @@ class _SequenceSession:
         result = self._results[self.calls - 1]
         if isinstance(result, Exception):
             raise result
+        assert isinstance(result, _FakeResponse)
         return _FakeRequestContext(result)
 
 
@@ -149,7 +150,7 @@ def test_normalize_api_uri() -> None:
     assert provider._normalize_api_uri(None) == ""
     assert provider._normalize_api_uri(" /api/v1/ ") == "/api/v1"
     with pytest.raises(ValidationError):
-        provider._normalize_api_uri(123)
+        provider._normalize_api_uri(123)  # type: ignore[arg-type]
 
 
 def test_merge_credentials() -> None:

--- a/tests/test_dvsportal_api.py
+++ b/tests/test_dvsportal_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import aiohttp
 import pytest
@@ -54,7 +55,7 @@ class _SequenceSession:
     def __init__(self, responses: list[object]) -> None:
         self._responses = responses
         self.calls = 0
-        self.requests: list[dict[str, object]] = []
+        self.requests: list[dict[str, Any]] = []
 
     def request(self, method: str, url: str, **kwargs) -> _FakeRequestContext:
         self.requests.append({"method": method, "url": url, "kwargs": kwargs})
@@ -62,6 +63,7 @@ class _SequenceSession:
         response = self._responses[self.calls - 1]
         if isinstance(response, Exception):
             raise response
+        assert isinstance(response, _FakeResponse)
         return _FakeRequestContext(response)
 
 
@@ -146,7 +148,7 @@ async def test_handle_rate_limit_raises_for_post() -> None:
     provider = _provider(_SequenceSession([]))
     response = _FakeResponse(status=429, headers={RETRY_AFTER_HEADER: "0"})
     with pytest.raises(ProviderError):
-        await provider._handle_rate_limit(response, "POST", attempt=0, attempts=2)
+        await provider._handle_rate_limit(response, "POST", attempt=0, attempts=2)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make DVSPortal login more robust across portal variants by preferring minimal Identifier/Password login and falling back to extended payload when needed
- keep backward compatibility for legacy internal helper usage via `_fetch_permit_media_type_id` wrapper
- enrich provider warning logs with context (municipality label), target host, and pycityvisitorparking package version
- pass request context from integration/client into provider instances
- update DVSPortal provider docs and tests for the new login behavior and known `/DVSPortal/api` municipalities

## Validation
- pre-commit hooks passed during commit (ruff, pyright, pytest)
