### PR TITLE
simplify release tooling and docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,11 +10,51 @@ tests:
       - any-glob-to-any-file:
           - "tests/**"
 
+bugfix:
+  - head-branch:
+      - "^bugfix(?:/|-.+|$)"
+      - "^fix(?:/|-.+|$)"
+      - "^hotfix(?:/|-.+|$)"
+
+new-feature:
+  - head-branch:
+      - "^feat(?:/|-.+|$)"
+      - "^feature(?:/|-.+|$)"
+
+refactor:
+  - head-branch:
+      - "^refactor(?:/|-.+|$)"
+
+performance:
+  - head-branch:
+      - "^perf(?:/|-.+|$)"
+      - "^performance(?:/|-.+|$)"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+github-actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
 maintenance:
   - changed-files:
       - any-glob-to-any-file:
-          - ".github/**"
           - "pyproject.toml"
+          - "uv.lock"
+          - ".pre-commit-config.yaml"
+          - ".github/CODEOWNERS"
+          - ".github/PULL_REQUEST_TEMPLATE.md"
+          - ".github/ISSUE_TEMPLATE/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "uv.lock"
+          - ".github/dependabot.yml"
 
 schema:
   - changed-files:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,103 @@
+- name: "breaking-change"
+  color: ee0701
+  description: "A breaking change for existing users."
+
+- name: "bug"
+  color: ee0701
+  description: "A reported bug or user-facing problem."
+
+- name: "bugfix"
+  color: ee0701
+  description: "A fix for a user-facing bug or behavioral issue."
+
+- name: "documentation"
+  color: 0052cc
+  description: "Solely about the documentation of the project."
+
+- name: "enhancement"
+  color: 1d76db
+  description: "Enhancement of the code, not introducing new features."
+
+- name: "feature"
+  color: 0e8a16
+  description: "A feature-related change."
+
+- name: "new-feature"
+  color: 0e8a16
+  description: "New features or options."
+
+- name: "refactor"
+  color: 1d76db
+  description: "Improvement of existing code, not introducing new features."
+
+- name: "performance"
+  color: 1d76db
+  description: "Improving performance, not introducing new features."
+
+- name: "maintenance"
+  color: 2af79e
+  description: "Generic maintenance tasks."
+
+- name: "ci"
+  color: 1d76db
+  description: "Work that improves the continuous integration setup."
+
+- name: "dependencies"
+  color: 1d76db
+  description: "Upgrade or downgrade of project dependencies."
+
+- name: "github-actions"
+  color: 1d76db
+  description: "Changes related to GitHub Actions workflows or automation."
+
+- name: "python"
+  color: 5319e7
+  description: "Changes primarily related to Python dependencies or tooling."
+
+- name: "tests"
+  color: bfdadc
+  description: "Adds or updates tests."
+
+- name: "schema"
+  color: c2e0c6
+  description: "Changes provider manifests or schema validation."
+
+- name: "major"
+  color: ee0701
+  description: "Marks a change that should trigger a major release."
+
+- name: "in-progress"
+  color: fbca04
+  description: "Issue or pull request is currently being worked on."
+
+- name: "stale"
+  color: fef2c0
+  description: "There has not been activity on this issue or PR for quite some time."
+
+- name: "no-stale"
+  color: fef2c0
+  description: "This issue or PR is exempted from stale automation."
+
+- name: "needs-more-information"
+  color: fef2c0
+  description: "More information is needed before this can be triaged further."
+
+- name: "security"
+  color: ee0701
+  description: "Marks a security issue that needs to be resolved quickly."
+
+- name: "incomplete"
+  color: fef2c0
+  description: "Marks a PR or issue that is missing information."
+
+- name: "invalid"
+  color: fef2c0
+  description: "Marks a PR or issue that is not actionable in its current form."
+
+- name: "beginner-friendly"
+  color: 0e8a16
+  description: "Good first issue for people wanting to contribute to the project."
+
+- name: "help-wanted"
+  color: 0e8a16
+  description: "Extra help or expertise is welcome to resolve this."

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,75 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+sort-direction: ascending
+
+categories:
+  - title: "Breaking changes"
+    labels:
+      - "breaking-change"
+      - "major"
+  - title: "New features"
+    labels:
+      - "new-feature"
+      - "feature"
+  - title: "Bug fixes"
+    labels:
+      - "bugfix"
+      - "bug"
+      - "fix"
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+      - "refactor"
+      - "performance"
+      - "schema"
+      - "tests"
+  - title: "Maintenance"
+    labels:
+      - "maintenance"
+      - "ci"
+      - "github-actions"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "Dependency updates"
+    labels:
+      - "dependencies"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "enhancement"
+      - "new-feature"
+      - "feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "bug"
+      - "fix"
+      - "ci"
+      - "dependencies"
+      - "documentation"
+      - "github-actions"
+      - "maintenance"
+      - "performance"
+      - "refactor"
+      - "schema"
+      - "tests"
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,35 @@
+name: Sync labels
+# yamllint disable-line rule:truthy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run label syncer
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,4 +1,5 @@
-name: PR labeler
+name: PR labels
+# yamllint disable-line rule:truthy
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] This workflow only applies labels and does not check out or run PR code.
@@ -16,13 +17,13 @@ permissions:
 
 jobs:
   label:
-    name: Apply labels
+    name: Label pull requests
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write # Required to apply and synchronize labels on the pull request.
     steps:
-      - name: Label pull request
+      - name: Run labeler
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+# yamllint disable-line rule:truthy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update_release_draft:
+    name: Draft release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@a6acf82562eee06318b77ab8cb0b11ed81c677a7 # v7.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,43 +4,43 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/pycityvisitorparking)](https://pypi.org/project/pycityvisitorparking/)
 [![CI](https://github.com/sir-Unknown/pyCityVisitorParking/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sir-Unknown/pyCityVisitorParking/actions/workflows/ci.yml)
 
-Async integration layer between Home Assistant and Dutch municipal visitor parking APIs.
+Async Python library for Dutch municipal visitor parking providers.
+
+The library exposes a small provider-agnostic API for:
+- provider discovery
+- permit lookup
+- reservation management
+- favorites management
+
+It is designed for Home Assistant use, but can also be used directly in any async Python application.
 
 ## Status
 
-This package ships the core client, provider interface, and discovery tooling,
-plus the following providers:
-
+Current bundled providers:
 - DVS Portal
 - The Hague
 - 2park
 
-`list_providers()` reads provider manifests under `src/pycityvisitorparking/provider/`.
+Provider manifests are discovered from `src/pycityvisitorparking/provider/` without importing all providers up front.
 
 Provider documentation:
-
-- DVS Portal: https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/dvsportal/README.md
-- The Hague: https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/the_hague/README.md
-- 2park: https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/2park/README.md
+- DVS Portal: <https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/dvsportal/README.md>
+- The Hague: <https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/the_hague/README.md>
+- 2park: <https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/2park/README.md>
 
 ## Supported municipalities
 
-For exact `base_url` and `api_uri` values, see the provider READMEs.
+For the exact `base_url`, `api_uri`, and provider-specific notes, see the provider README files.
 
-- DVS Portal: Apeldoorn, Bloemendaal, Delft, Den Bosch, Doetinchem (via Buha), Groningen,
-  Haarlem, Harlingen, Heemstede, Heerenveen, Heerlen, Hengelo, Katwijk, Leiden,
-  Leidschendam-Voorburg, Middelburg, Nissewaard, Oldenzaal, Rijswijk, Roermond,
-  Schouwen-Duiveland, Sittard-Geleen, Smallingerland, Sudwest-Fryslan, Veere, Venlo,
-  Vlissingen, Waadhoeke, Waalwijk, Weert, Zaanstad, Zevenaar, Zutphen, Zwolle
+- DVS Portal: Apeldoorn, Bloemendaal, Delft, Den Bosch, Doetinchem (via Buha), Groningen, Haarlem, Harlingen, Heemstede, Heerenveen, Heerlen, Hengelo, Katwijk, Leiden, Leidschendam-Voorburg, Middelburg, Nissewaard, Oldenzaal, Rijswijk, Roermond, Schouwen-Duiveland, Sittard-Geleen, Smallingerland, Sudwest-Fryslan, Veere, Venlo, Vlissingen, Waadhoeke, Waalwijk, Weert, Zaanstad, Zevenaar, Zutphen, Zwolle
 - The Hague: The Hague
-- 2park: Amstelveen, Assen, Bergen op Zoom, Breda, Deventer, Dordrecht, Eindhoven,
-  Emmen, Etten-Leur, Gorinchem, Hardenberg, Harderwijk, Maastricht, Oosterhout, Oss,
-  Roosendaal, Sluis, Terneuzen, Tiel, Veenendaal, Vlaardingen
-  (non-exhaustive — check [mijn.2park.nl](https://mijn.2park.nl) for the current list)
+- 2park: Amstelveen, Assen, Bergen op Zoom, Breda, Deventer, Dordrecht, Eindhoven, Emmen, Etten-Leur, Gorinchem, Hardenberg, Harderwijk, Maastricht, Oosterhout, Oss, Roosendaal, Sluis, Terneuzen, Tiel, Veenendaal, Vlaardingen
+
+The 2park list is non-exhaustive. Check <https://mijn.2park.nl> for the current provider coverage.
 
 ## Installation
 
-Requires Python 3.13+.
+Requires Python 3.14 or newer.
 
 ```bash
 pip install pycityvisitorparking
@@ -55,17 +55,63 @@ from pycityvisitorparking import Client
 
 
 async def main() -> None:
-    async with Client(base_url="https://example") as client:
+    async with Client(base_url="https://example", api_uri="/api") as client:
         provider = await client.get_provider("dvsportal")
         await provider.login(credentials={"username": "user", "password": "secret"})
+
         permit = await provider.get_permit()
+        reservations = await provider.list_reservations()
+
         print(permit)
+        print(reservations)
 
 
 asyncio.run(main())
 ```
 
-## Usage
+## Public API
+
+### Client
+
+`Client` is the main entry point.
+
+- `list_providers()` returns available `ProviderInfo` objects.
+- `get_provider(provider_id, ...)` loads a specific provider on demand.
+- `Client` accepts an optional injected `aiohttp.ClientSession`.
+- If you do not inject a session, the client creates and owns its own session.
+
+Configuration options:
+- `base_url`: provider base URL
+- `api_uri`: optional provider API path
+- `timeout`: optional `aiohttp.ClientTimeout`
+- `retry_count`: retry count for idempotent GET requests
+
+### Data models
+
+The public data models are:
+- `ProviderInfo`
+- `Permit`
+- `ZoneValidityBlock`
+- `Reservation`
+- `Favorite`
+
+Model highlights:
+- `ProviderInfo` includes `id`, `favorite_update_fields`, `reservation_update_fields`, and `balance_units`
+- `Permit` includes `id`, `remaining_balance`, `balance_unit`, and `zone_validity`
+- `ZoneValidityBlock` contains UTC ISO 8601 `start_time` and `end_time`
+- `Reservation` includes `id`, `name`, `license_plate`, `start_time`, and `end_time`
+- `Favorite` includes `id`, `name`, and `license_plate`
+
+### Standardized behavior
+
+- Timestamps are returned as UTC ISO 8601 strings.
+- License plates are normalized and validated.
+- The public API stays provider-agnostic.
+- Some update operations may be unsupported by a provider; inspect `favorite_update_fields` and `reservation_update_fields`.
+
+## Common usage
+
+List providers:
 
 ```python
 import asyncio
@@ -75,110 +121,14 @@ from pycityvisitorparking import Client
 
 async def main() -> None:
     async with Client() as client:
-        providers = await client.list_providers()
-        print(providers)
+        for provider in await client.list_providers():
+            print(provider.id, provider.reservation_update_fields)
 
 
 asyncio.run(main())
 ```
 
-## Configuration
-
-- `base_url` is required for provider requests.
-- `api_uri` is optional; providers may define a default (see provider README).
-- Credentials are standardized: `username` and `password` are required.
-- Provider-specific optional fields (for example `permit_media_type_id`) are
-  documented in each provider README.
-
-## Releases
-
-Releases publish from GitHub Actions when a GitHub release is published.
-Create a draft release for tag `vX.Y.Z`, then publish it to trigger PyPI
-publishing.
-
-## Async behavior
-
-Provider discovery (`list_providers()`, `get_provider()`) runs in background
-threads so async callers avoid blocking the event loop.
-
-## Available data
-
-The public API exposes a small, provider-agnostic set of models and operations.
-Provider READMEs list credential requirements and any unsupported operations.
-
-- Providers: `list_providers()` returns `ProviderInfo` with `id`,
-  `favorite_update_fields`, and `reservation_update_fields`.
-- Permit: `get_permit()` returns `Permit` with `id`, `remaining_balance` (minutes), and `zone_validity`.
-- Zone validity: each `ZoneValidityBlock` includes `start_time` and `end_time` (UTC ISO 8601).
-- Reservations: `list_reservations()`, `start_reservation()`, `update_reservation()`, and
-  `end_reservation()` return `Reservation` with `id`, `name`, `license_plate`,
-  `start_time`, and `end_time`.
-  Some providers only support updating `end_time` (see `reservation_update_fields`).
-- Favorites: `list_favorites()` and `add_favorite()` return `Favorite` with `id`, `name`,
-  and `license_plate`. `update_favorite()` returns `Favorite` when supported
-  (`favorite_update_fields` is non-empty), otherwise it raises `ProviderError`.
-  `remove_favorite()` removes the entry without returning data.
-
-### Examples
-
-Providers (`list_providers()`):
-
-```python
-import asyncio
-
-from pycityvisitorparking import Client
-
-
-async def main() -> None:
-    async with Client() as client:
-        providers = await client.list_providers()
-        for info in providers:
-            print(info.id, info.favorite_update_fields, info.reservation_update_fields)
-
-
-asyncio.run(main())
-```
-
-Permit (`get_permit()`):
-
-```python
-import asyncio
-
-from pycityvisitorparking import Client
-
-
-async def main() -> None:
-    async with Client(base_url="https://example", api_uri="/api") as client:
-        provider = await client.get_provider("dvsportal")
-        await provider.login(credentials={"username": "user", "password": "secret"})
-        permit = await provider.get_permit()
-        print(permit.id, permit.remaining_balance)
-
-
-asyncio.run(main())
-```
-
-Zone validity (`ZoneValidityBlock`):
-
-```python
-import asyncio
-
-from pycityvisitorparking import Client
-
-
-async def main() -> None:
-    async with Client(base_url="https://example", api_uri="/api") as client:
-        provider = await client.get_provider("dvsportal")
-        await provider.login(credentials={"username": "user", "password": "secret"})
-        permit = await provider.get_permit()
-        for block in permit.zone_validity:
-            print(block.start_time, block.end_time)
-
-
-asyncio.run(main())
-```
-
-Reservations (`list_reservations()`, `start_reservation()`, `update_reservation()`, `end_reservation()`):
+Manage a reservation:
 
 ```python
 import asyncio
@@ -192,11 +142,9 @@ async def main() -> None:
         provider = await client.get_provider("dvsportal")
         await provider.login(credentials={"username": "user", "password": "secret"})
 
-        reservations = await provider.list_reservations()
-        print([reservation.id for reservation in reservations])
-
         start_time = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
         end_time = start_time + timedelta(hours=2)
+
         reservation = await provider.start_reservation(
             "12AB34",
             start_time=start_time,
@@ -204,22 +152,13 @@ async def main() -> None:
             name="Visitor",
         )
 
-        if "end_time" in provider.reservation_update_fields:
-            new_end_time = end_time + timedelta(hours=1)
-            reservation = await provider.update_reservation(
-                reservation.id,
-                end_time=new_end_time,
-            )
-            end_time = new_end_time
-
-        ended = await provider.end_reservation(reservation.id, end_time=end_time)
-        print(ended.id, ended.start_time, ended.end_time)
+        print(reservation.id)
 
 
 asyncio.run(main())
 ```
 
-Favorites (`list_favorites()`, `add_favorite()`, `update_favorite()`, `remove_favorite()`):
+Manage favorites:
 
 ```python
 import asyncio
@@ -233,66 +172,35 @@ async def main() -> None:
         provider = await client.get_provider("dvsportal")
         await provider.login(credentials={"username": "user", "password": "secret"})
 
-        favorites = await provider.list_favorites()
-        print([favorite.id for favorite in favorites])
-
         favorite = await provider.add_favorite("12AB34", name="Visitor")
-        try:
-            favorite = await provider.update_favorite(favorite.id, name="Visitor 2")
-            print(favorite.id, favorite.name, favorite.license_plate)
-        except ProviderError:
-            pass
 
-        await provider.remove_favorite(favorite.id)
+        try:
+            updated = await provider.update_favorite(favorite.id, name="Visitor 2")
+            print(updated)
+        except ProviderError:
+            print("Favorite updates are not supported by this provider")
 
 
 asyncio.run(main())
 ```
 
-## Provider framework
-
-Providers are discovered via `manifest.json` files without importing provider
-modules. Discovery runs in a background thread to avoid blocking the event loop.
-To add a provider later, create:
-
-```
-src/pycityvisitorparking/provider/<provider_id>/
-  manifest.json
-  __init__.py
-  api.py
-  const.py
-  README.md
-  CHANGELOG.md
-```
-
-Only files under `src/pycityvisitorparking/provider/<provider_id>/` should change
-in a provider PR.
-
-Manifest loading is cached (5-minute TTL); pass `refresh=True` or call
-`clear_manifest_cache()` to force a reload. If you use loader helpers directly,
-prefer their `async_*` variants to avoid blocking the event loop.
-
-Credential inputs are standardized: pass `username` and `password` to
-`login()` for all providers. Provider READMEs list any optional fields such as
-`permit_media_type_id`.
-
 ## Error handling
 
-Public methods raise library exceptions instead of raw `aiohttp` errors:
+Public methods raise library exceptions instead of raw `aiohttp` exceptions:
 
-- `AuthError`: authentication failures (HTTP 401/403 or provider auth rejection).
-- `NetworkError`: network/timeout failures.
-- `ValidationError`: invalid inputs (timestamps, plates, missing fields).
-- `ProviderError`: provider responses or request failures not covered above.
-- Optional specific errors: `RateLimitError`, `ServiceUnavailableError`,
-  `NotFoundError`, `TimeoutError`, and `ConfigError` for finer-grained handling.
+- `AuthError`
+- `NetworkError`
+- `ValidationError`
+- `ProviderError`
+- `RateLimitError`
+- `ServiceUnavailableError`
+- `NotFoundError`
+- `TimeoutError`
+- `ConfigError`
 
-Exceptions include a short `detail` string and a normalized `error_code`
-(`auth_error`, `network_error`, `validation_error`, `provider_error`). You can
-optionally pass a `user_message` that is safe to display directly. Exception
-messages avoid credentials and full license plates.
+Each exception includes normalized metadata such as `error_code`, `detail`, and optional `user_message`.
 
-Example handling:
+Example:
 
 ```python
 from pycityvisitorparking import Client
@@ -313,48 +221,51 @@ async with Client(base_url=base_url, api_uri=api_uri) as client:
 
 ## Logging
 
-The library logs diagnostic events to the `pycityvisitorparking` logger using
-the standard Python `logging` module. Configure handlers and levels in your
-application to enable debugging output. Logs avoid credentials and full license
-plates.
+The library logs to the `pycityvisitorparking` logger using the standard Python `logging` module.
 
-## Normalization rules
-
-- Public APIs accept only timezone-aware `datetime` values; naive timestamps raise
-  `ValidationError`.
-- All public timestamps are normalized to UTC ISO 8601 with `Z` and second
-  precision (microseconds are truncated).
-- Internally, reservation times are handled as timezone-aware UTC `datetime`
-  values and serialized to strings only at provider and model boundaries.
-- License plates are normalized to uppercase `A-Z0-9` without spaces/symbols.
-- Adding a favorite that already exists by license plate raises `ValidationError`.
-- `zone_validity` must include only chargeable windows.
+- credentials are not logged
+- full license plates are not logged
+- request context can be attached for clearer diagnostics
 
 ## Development
 
-Before running checks or opening diagnostics in VS Code, sync the dev
-environment in the local project venv:
+This repository uses `uv` for local development tasks.
+
+Common checks:
 
 ```bash
-cd /workspaces/pyCityVisitorParking
-uv sync --group dev
+uv run --group lint ruff check .
+uv run --group lint ruff format --check .
+uv run --group typecheck pyright
+uv run --group test pytest
+uv run --group schema python -m pytest -o addopts=-q tests/test_manifest_schema.py
+uv build
+uvx twine check dist/*
 ```
 
-Run checks with Hatch:
+Release notes and publishing are handled through GitHub Actions. See [docs/RELEASING.md](docs/RELEASING.md).
 
-```bash
-hatch run lint:check
-hatch run lint:format-check
-hatch run test:run
+## Provider development
+
+Providers live under `src/pycityvisitorparking/provider/<provider_id>/`.
+
+A provider folder typically contains:
+
+```text
+src/pycityvisitorparking/provider/<provider_id>/
+  manifest.json
+  __init__.py
+  api.py
+  const.py
+  README.md
+  CHANGELOG.md
 ```
 
-Build artifacts:
-
-```bash
-hatch build
-python -m twine check dist/*
-```
+Related docs:
+- Provider framework: [src/pycityvisitorparking/provider/README.md](src/pycityvisitorparking/provider/README.md)
+- Provider template: [docs/provider-template/README.md](docs/provider-template/README.md)
+- Provider development guide: [docs/provider-development/README.md](docs/provider-development/README.md)
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,18 +1,18 @@
 # RELEASING.md — Release & Publish Guide (pyCityVisitorParking)
 
-✅ **Publish via CI using Trusted Publishing (OIDC)**
-- Publish releases from GitHub Actions using OIDC.
-- ❌ Avoid publishing from local machines when CI publishing is available.
-- ❌ Avoid PyPI API tokens when OIDC is available.
+✅ **Use the current release source of truth**
+- The package version is derived from git tags via `hatch-vcs`.
+- Do not edit a version string in the repository for releases.
+- The release tag must match `vX.Y.Z`.
 
 ✅ **Use SemVer and keep changelogs accurate**
-- Use SemVer for the package version.
+- Use SemVer for release tags.
 - Bump MINOR for provider additions.
 - Bump PATCH for bug fixes.
-- Maintain an “Unreleased” section in:
+- Maintain an `Unreleased` section in:
   - root `CHANGELOG.md`
   - each provider `CHANGELOG.md`
-- Move “Unreleased” entries into a versioned section on release.
+- Move `Unreleased` entries into a versioned section before tagging a release.
 
 ✅ **Update documentation before releasing**
 - Update root `README.md` when public behavior changes.
@@ -20,104 +20,96 @@
 - Update provider `README.md` and provider `CHANGELOG.md` for provider changes:
   - auth flow changes
   - endpoint changes
-  - mapping changes (UTC conversion, zone_validity filtering)
+  - mapping changes (UTC conversion, `zone_validity` filtering)
   - limitations or known issues
 
-✅ **Run all checks locally using Hatch**
-- Run formatting checks:
-  - `hatch run lint:format-check`
+✅ **Validate the release locally with the current toolchain**
+- Set up the project environment with `uv`.
 - Run lint:
-  - `hatch run lint:check`
+  - `uv run --group lint ruff check .`
+  - `uv run --group lint ruff format --check .`
+- Run type checking:
+  - `uv run --group typecheck pyright`
 - Run tests:
-  - `hatch run test:run`
-- Build artifacts (clean):
-  - `hatch build -c`
+  - `uv run --group test pytest`
+- Validate provider manifests:
+  - `uv run --group schema python -m pytest -o addopts=-q tests/test_manifest_schema.py`
+- Build artifacts:
+  - `uv build`
 - Validate artifacts:
-  - `python -m twine check dist/*`
+  - `uvx twine check dist/*`
 
-✅ **Bump the version using Hatch**
-- Bump patch/minor/major:
-  - `hatch version patch`
-  - `hatch version minor`
-  - `hatch version major`
-- Or set an explicit version:
-  - `hatch version X.Y.Z`
+Do not push release tags before the local checks and artifact validation pass.
 
-✅ **Recommended local release order**
-1) Update docs and changelogs.
-2) `hatch run lint:format-check`
-3) `hatch run lint:check`
-4) `hatch run test:run`
-5) `hatch build -c`
-6) `python -m twine check dist/*`
-7) `rm -rf dist` (optional cleanup after checks)
-8) `hatch version X.Y.Z`
-9) `git commit -am "Release X.Y.Z"`
-10) `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
-11) `git push --follow-tags`
+✅ **Use Release Drafter as a draft aid, not as the release source of truth**
+- Release Drafter keeps a draft GitHub release up to date from merged pull requests.
+- Review and edit the generated notes before publishing.
+- The final published release must still be created from the real git tag you intend to publish.
+- If the draft release points at the wrong commit, retarget it to the release tag before publishing.
 
-Do not push tags before running build + twine checks locally.
+✅ **Current release flow**
+1. Update docs and changelogs on the release commit.
+2. Run the local validation steps listed above.
+3. Commit the release changes.
+4. Create an annotated tag:
+   - `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
+5. Push the release commit and tag:
+   - `git push`
+   - `git push origin vX.Y.Z`
+6. Confirm the `CI` workflow passes for the tag.
+7. Publish the GitHub release for tag `vX.Y.Z`.
+8. The `Release` workflow will build from that tag and publish to PyPI using OIDC.
 
-✅ **Commit and tag the release**
-- Commit release changes:
-  - `git commit -am "Release vX.Y.Z"`
-- Create a version tag:
-  - `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
-- Push commits and tags:
-  - `git push --follow-tags`
-
-✅ **Publish to PyPI from GitHub Actions**
-- Publish a GitHub release for tag `vX.Y.Z` to trigger the release workflow.
-- Creating or editing a draft release does not publish to PyPI; the workflow runs when you click `Publish release`.
-- Ensure the workflow:
+✅ **Understand what GitHub Actions does**
+- `CI` runs on pull requests, pushes to `main`, manual dispatch, and tags matching `v*`.
+- `Release Drafter` updates the draft release on `main` pushes and PR updates.
+- `Release` runs only when a GitHub release is published.
+- The publish workflow:
+  - validates that the published release tag matches `vX.Y.Z`
+  - checks out the repository at that exact tag
+  - logs the resolved package version
   - builds `sdist` and `wheel`
-  - verifies artifacts (`twine check`)
-  - publishes using `pypa/gh-action-pypi-publish` with OIDC
+  - runs `twine check`
+  - publishes to PyPI using `pypa/gh-action-pypi-publish`
 
 ✅ **Validate tag and version alignment**
-- The package version is derived from the git tag via `hatch-vcs`.
-- Create the GitHub release from the intended `vX.Y.Z` tag on the release commit; the build will use that tag as the package version.
+- Because the version comes from VCS metadata, the tag is the version source of truth.
+- Create the GitHub release from the intended `vX.Y.Z` tag on the release commit.
+- Do not publish a GitHub release from an untagged commit or from the wrong tag.
 
-✅ **Use TestPyPI for a dry run**
-- Use a separate test repository or temporary publishing workflow if you want to validate the full GitHub release flow without touching the production PyPI project.
+✅ **Configure Trusted Publishing (OIDC)**
+- Configure the PyPI project to trust this repository and workflow.
+- Ensure the GitHub Actions environment used for publishing is authorized in PyPI.
+- The publish workflow requires:
+  - `id-token: write`
 
-✅ **Configure Trusted Publishing (OIDC) on PyPI/TestPyPI**
-- Open PyPI/TestPyPI → project settings → trusted publishers.
-- Add:
-  - GitHub owner/repo
-  - workflow name
-  - optional environment restrictions
-- Ensure GitHub Actions has:
-  - `permissions: id-token: write`
-
-✅ **Verify release contents (sdist)**
-- Confirm the `sdist` contains:
+✅ **Verify release contents**
+- Confirm the built distribution contains:
   - all provider `manifest.json` files
   - `manifest.schema.json`
   - provider `README.md` and provider `CHANGELOG.md`
   - root `README.md` and root `CHANGELOG.md`
-
-✅ **Enforce schema validation in CI**
-- Keep the manifest schema validation test enabled.
-- Fail CI if any provider manifest violates the schema.
+  - `docs/RELEASING.md`
 
 ✅ **Troubleshoot publishing issues systematically**
-- Fix lint/test failures first.
-- Fix packaging inclusion issues next (missing files in `sdist`).
+- Fix lint, type-check, and test failures first.
+- Fix packaging inclusion issues next.
 - Re-run:
-  - `hatch build`
-  - `python -m twine check dist/*`
-- Prefer releasing a new PATCH version over re-tagging.
+  - `uv build`
+  - `uvx twine check dist/*`
+- Prefer releasing a new PATCH version over deleting or reusing a broken tag.
 
 ❌ **Avoid these anti-patterns**
-- Do not publish directly from a laptop if CI publish exists.
+- Do not publish directly from a laptop when CI publishing is available.
 - Do not skip changelog updates.
+- Do not create a GitHub release before the intended tag exists on GitHub.
+- Do not retag an existing version after publication.
 - Do not introduce new runtime dependencies without reviewing Home Assistant compatibility.
-- Do not break the “provider PR scope rule” (provider changes should remain provider-folder-only).
+- Do not break the provider PR scope rule unnecessarily.
 
 ✅ **Rollback safely using PyPI yanks**
-- Use a **yank** when a release is broken but you want to keep the version recorded.
-- Prefer yanking over deleting, because deleting can break reproducibility for users.
+- Yank a release when the published package is broken but should remain part of the public record.
+- Prefer yanking over deleting because deletion harms reproducibility.
 
 ✅ **Choose the right recovery strategy**
 - Yank a release when:
@@ -127,23 +119,17 @@ Do not push tags before running build + twine checks locally.
 - Publish a new PATCH release when:
   - you have a fix ready
   - you want users to move forward automatically
-- Avoid deleting releases unless PyPI policy requires it.
 
 ✅ **Perform a yank on PyPI**
 - Open the project on PyPI.
-- Open the specific release/version.
-- Mark the release files as **yanked**.
-- Add a clear yank reason that tells users what to do next (e.g. “Use vX.Y.(Z+1)”).
+- Open the affected release.
+- Mark the release files as yanked.
+- Add a clear yank reason that tells users what to do next, for example `Use vX.Y.(Z+1)`.
 
 ✅ **Publish a follow-up PATCH release**
 - Fix the issue on `main`.
 - Update root `CHANGELOG.md` and the affected provider `CHANGELOG.md`.
-- Bump the version with Hatch:
-  - `hatch version patch`
-- Tag and push:
-  - `git tag vX.Y.(Z+1)`
-  - `git push --follow-tags`
-- Let CI publish the new version via OIDC.
+- Repeat the same tag-driven release flow with the next PATCH version.
 
 ✅ **Communicate the rollback**
 - Add a short note to root `CHANGELOG.md` explaining:
@@ -153,5 +139,5 @@ Do not push tags before running build + twine checks locally.
 - Add provider-specific notes in the provider `CHANGELOG.md` when applicable.
 
 ✅ **Prevent recurrence**
-- Add or extend tests for the failure mode (mapping, parsing, schema, etc.).
+- Add or extend tests for the failure mode.
 - Keep provider fixtures updated to cover the problematic payload.

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -37,7 +37,9 @@ except PackageNotFoundError:  # pragma: no cover - source tree fallback
 class _HttpSession(Protocol):
     """Minimal interface required from an HTTP session."""
 
-    def request(self, method: str, url: str, **kwargs: Any) -> Any: ...
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        """Make an HTTP request."""
+        pass
 
 
 class BaseProvider(ABC):


### PR DESCRIPTION
## Summary

This PR simplifies the repository release flow and aligns the supporting docs and labeling setup with the current GitHub Actions workflow.

## What changed

- added Release Drafter workflow and configuration
- added a label sync workflow plus central `.github/labels.yml`
- refreshed PR auto-labeling to better match release categories
- updated `docs/RELEASING.md` to reflect the current tag-driven `uv` + GitHub release flow
- cleaned up `README.md` and removed outdated release/development guidance

## Why

The repository had a mix of older release documentation and newer workflow behavior. This change makes the release tooling, labels, and documentation consistent and easier to maintain.

## Validation

- pre-commit hooks passed during commit
- `zizmor` passed after pinning the Release Drafter action
- `yamllint` passed
- `pyright` passed
- `pytest` passed