### PR TITLE
fix Release Drafter token permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,9 @@ jobs:
   update_release_draft:
     name: Draft release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - name: Run Release Drafter


### PR DESCRIPTION
## Summary
Grant the Release Drafter workflow the repository token scopes it needs to update the draft release.

## Why
The workflow sets `permissions: {}` at the top level, and the `update_release_draft` job did not override that. As a result, `GITHUB_TOKEN` lacked the write access needed for Release Drafter to create or update draft releases on pushes to `main`.

## What changed
- added job-level `contents: write`
- added job-level `pull-requests: read`
- kept the restrictive top-level permissions block in place

## Impact
Release Drafter can now update the draft release without broadening permissions for the rest of the workflow.

## Validation
- committed from a clean branch based on `main`
- local commit hooks passed, including `yamllint`, `zizmor`, `codespell`, `pyright`, and `pytest`
