### PR TITLE
Improve devcontainer and VS Code setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:debian",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/astral-sh/uv:latest": {}
+    "ghcr.io/devcontainer-community/devcontainer-features/astral.sh-uv:1": {}
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "remoteEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,14 +6,14 @@
     "ghcr.io/astral-sh/uv:latest": {}
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
+  "remoteEnv": {
+    "VIRTUAL_ENV": "${containerWorkspaceFolder}/.venv",
+    "PATH": "${containerWorkspaceFolder}/.venv/bin:${containerEnv:PATH}"
+  },
   "customizations": {
     "vscode": {
       "settings": {
         "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
-        "terminal.integrated.env.linux": {
-          "VIRTUAL_ENV": "${containerWorkspaceFolder}/.venv",
-          "PATH": "${containerWorkspaceFolder}/.venv/bin:${env:PATH}"
-        },
         "editor.formatOnSave": true,
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff"
@@ -25,7 +25,8 @@
         "charliermarsh.ruff",
         "ms-python.debugpy",
         "github.vscode-github-actions",
-        "anthropic.claude-code"
+        "anthropic.claude-code",
+        "tamasfe.even-better-toml"
       ]
     }
   },

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -4,14 +4,9 @@ set -e
 REPO_DIR="$(git rev-parse --show-toplevel)"
 VENV_DIR="$REPO_DIR/.venv"
 
-echo "🐍 Installing Python $(cat "$REPO_DIR/.python-version")..."
-uv python install "$(cat "$REPO_DIR/.python-version")"
-uv venv "$VENV_DIR" --python "$(cat "$REPO_DIR/.python-version")"
-
-source "$VENV_DIR/bin/activate"
-
 echo "📦 Installing package (editable) + dev extras..."
-uv pip install -e '.[dev]'
+cd "$REPO_DIR"
+uv sync --group dev
 
 # ── Activate venv in shell profiles ──────────────────────────────
 for profile in ~/.bashrc ~/.zshrc; do
@@ -21,8 +16,7 @@ for profile in ~/.bashrc ~/.zshrc; do
 done
 
 echo "🪝 Installing pre-commit hooks..."
-cd "$REPO_DIR"
-pre-commit install
+uv run pre-commit install
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,12 @@
 {
   "recommendations": [
     "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "ms-python.debugpy",
     "ms-python.pylint",
-    "charliermarsh.ruff"
+    "github.vscode-github-actions",
+    "anthropic.claude-code",
+    "tamasfe.even-better-toml"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "python.defaultInterpreterPath": "/workspaces/pyCityVisitorParking/.venv/bin/python",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "ruff.path": ["${workspaceFolder}/.venv/bin/ruff"],
   "pylint.enabled": true,
   "pylint.args": ["--rcfile=pyproject.toml"],
   "pylint.importStrategy": "fromEnvironment",


### PR DESCRIPTION
## What changed
This separates the development environment updates into their own PR.

It updates the devcontainer to expose the virtual environment through `remoteEnv`, switches setup to `uv sync --group dev`, and refreshes the recommended VS Code extensions and workspace settings.

## Why
These changes are editor and container workflow improvements and should stay independent from the release-version work on `fix/release-version-resolution`.

## Impact
Developers get a more consistent `.venv`-based setup in the container and aligned VS Code recommendations/settings.

## Validation
- Local commit hooks passed
- `pytest` passed during commit