### PR TITLE
Fix except syntax in 2Park balance parser

### DIFF
--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -570,7 +570,7 @@ def _parse_balance_amount(balance: dict[str, Any]) -> float:
             raw = param.get("prr_value")
             try:
                 return float(raw)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 return 0.0
     return 0.0
 


### PR DESCRIPTION
## Summary
- replace old-style multi-exception syntax in `_parse_balance_amount`
- use tuple syntax compatible with modern Python

## Validation
- pre-commit checks ran during commit (formatter loop observed on this file)
- branch pushed successfully