### PR TITLE
feat: fetch_all, demo provider, and 502/503/504 NetworkError handling

### DIFF
--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json as _json
 import re
 from collections.abc import Mapping
@@ -285,6 +286,30 @@ class Provider(BaseProvider):
         favorites = self._map_favorite_list(details)
         self._log_operation_completed("list_favorites", count=len(favorites))
         return favorites
+
+    async def fetch_all(self) -> tuple[Permit, list[Reservation], list[Favorite]]:
+        """Return permit, reservations, and favorites with two parallel provider fetches."""
+        self._log_operation_started("fetch_all")
+        await self._ensure_authenticated()
+        permit_data, details = await asyncio.gather(
+            self._post_form(
+                BALANCE_ENDPOINT,
+                {"product_id": self._product_id or "", "locale": LOCALE},
+            ),
+            self._post_form(
+                PRODUCT_DETAILS_ENDPOINT,
+                {"product_id": self._product_id or "", "locale": LOCALE},
+            ),
+        )
+        permit = self._map_permit(permit_data)
+        reservations = self._map_reservation_list(details)
+        favorites = self._map_favorite_list(details)
+        self._log_operation_completed(
+            "fetch_all",
+            reservations=len(reservations),
+            favorites=len(favorites),
+        )
+        return permit, reservations, favorites
 
     async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
         """Add a favorite."""

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -53,7 +53,6 @@ _SENSITIVE_KEYS = frozenset(
 )
 _SENSITIVE_OBJECT_KEYS = frozenset({"LicensePlate", "licensePlate", "updateLicensePlate"})
 _SENSITIVE_NESTED_KEYS = frozenset({"DisplayValue", "Name", "Value"})
-_LOGGER = get_provider_logger(__name__)
 _T = TypeVar("_T")
 
 try:

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Iterable, Mapping
@@ -96,7 +97,8 @@ class BaseProvider(ABC):
         self._request_context_name: str | None = None
         self._ha_cvp_version = "unknown"
         self._pycvp_version = PACKAGE_VERSION
-        _LOGGER.debug(
+        self._logger = get_provider_logger(type(self).__module__)
+        self._logger.debug(
             "Provider %s initialized base_url=%s api_uri=%s",
             self._manifest.id,
             self._base_url,
@@ -156,7 +158,7 @@ class BaseProvider(ABC):
     def _log_with_metadata(self, level: int, message: str, *args: Any) -> None:
         """Log a message with the standard provider metadata suffix."""
         provider, city, ha_cvp, pycvp = self._request_log_metadata()
-        _LOGGER.log(
+        self._logger.log(
             level,
             f"{message} (provider=%s, city=%s, hacvp=%s, pycvp=%s)",
             *args,
@@ -183,7 +185,7 @@ class BaseProvider(ABC):
             lines.append(f"  {detail}")
         for key, value in all_fields.items():
             lines.append(f"  {key:<{width}} = {value}")
-        _LOGGER.warning("%s", "\n".join(lines))
+        self._logger.warning("%s", "\n".join(lines))
 
     def _format_log_details(self, **details: Any) -> str:
         """Serialize optional log details as a compact key=value suffix."""
@@ -193,7 +195,7 @@ class BaseProvider(ABC):
 
     def _log_operation_started(self, operation: str, **details: Any) -> None:
         """Log the start of a provider operation."""
-        _LOGGER.debug(
+        self._logger.debug(
             "Provider %s %s started%s",
             self.provider_id,
             operation,
@@ -202,7 +204,7 @@ class BaseProvider(ABC):
 
     def _log_operation_completed(self, operation: str, **details: Any) -> None:
         """Log successful completion of a provider operation."""
-        _LOGGER.debug(
+        self._logger.debug(
             "Provider %s %s completed%s",
             self.provider_id,
             operation,
@@ -211,7 +213,7 @@ class BaseProvider(ABC):
 
     def _log_operation_failed(self, operation: str, reason: str, **details: Any) -> None:
         """Log a provider operation failure before raising a validation/provider error."""
-        _LOGGER.debug(
+        self._logger.debug(
             "Provider %s %s failed: %s%s",
             self.provider_id,
             operation,
@@ -225,7 +227,7 @@ class BaseProvider(ABC):
 
     def _log_reauthenticating(self) -> None:
         """Log when cached credentials are used to reauthenticate."""
-        _LOGGER.debug(
+        self._logger.debug(
             "Provider %s reauthenticating with cached credentials",
             self.provider_id,
         )
@@ -238,7 +240,7 @@ class BaseProvider(ABC):
 
     def _log_response_status(self, status: int) -> None:
         """Log the HTTP response status returned by a provider."""
-        _LOGGER.debug("Provider %s response status=%s", self.provider_id, status)
+        self._logger.debug("Provider %s response status=%s", self.provider_id, status)
 
     def _summarize_log_text(self, value: str) -> str:
         """Normalize and truncate response text for safe logging."""
@@ -350,7 +352,7 @@ class BaseProvider(ABC):
 
     def _log_response_summary(self, data: Any) -> None:
         """Log a safe debug summary of a successful JSON response."""
-        _LOGGER.debug(
+        self._logger.debug(
             "Provider %s response summary %s",
             self.provider_id,
             self._mask_log_value(self._build_response_summary(data)),
@@ -589,7 +591,7 @@ class BaseProvider(ABC):
         last_error: Exception | None = None
         for attempt in range(attempts):
             if attempts > 1:
-                _LOGGER.debug(
+                self._logger.debug(
                     "Provider %s request %s %s (attempt %s/%s)",
                     self.provider_id,
                     method.upper(),
@@ -598,7 +600,7 @@ class BaseProvider(ABC):
                     attempts,
                 )
             else:
-                _LOGGER.debug(
+                self._logger.debug(
                     "Provider %s request %s %s",
                     self.provider_id,
                     method.upper(),
@@ -606,7 +608,7 @@ class BaseProvider(ABC):
                 )
             payload = request_kwargs.get("json")
             if payload is not None:
-                _LOGGER.debug(
+                self._logger.debug(
                     "Provider %s request payload %s",
                     self.provider_id,
                     self._mask_payload(payload),
@@ -703,6 +705,8 @@ class BaseProvider(ABC):
         )
         if response.status in (401, 403):
             raise AuthError("Authentication failed.")
+        if response.status in (502, 503, 504):
+            raise NetworkError(f"Provider temporarily unavailable (status {response.status}).")
         raise ProviderError(f"Provider request failed with status {response.status}.")
 
     def _normalize_base_url(self, base_url: str | None) -> str | None:
@@ -721,6 +725,20 @@ class BaseProvider(ABC):
         if not normalized:
             return ""
         return f"/{normalized}"
+
+    async def fetch_all(self) -> tuple[Permit, list[Reservation], list[Favorite]]:
+        """Return permit, reservations, and favorites in a single batch.
+
+        Providers that serve all three from a single HTTP response should override
+        this method for efficiency. The default implementation calls the three
+        individual methods concurrently.
+        """
+        permit, reservations, favorites = await asyncio.gather(
+            self.get_permit(),
+            self.list_reservations(),
+            self.list_favorites(),
+        )
+        return permit, reservations, favorites
 
     @abstractmethod
     async def login(
@@ -782,7 +800,7 @@ class BaseProvider(ABC):
     ) -> Favorite:
         """Update a favorite."""
         if not self.favorite_update_possible:
-            _LOGGER.info(
+            self._logger.info(
                 "Provider %s favorite update requested but not supported",
                 self.provider_id,
             )

--- a/src/pycityvisitorparking/provider/demo/__init__.py
+++ b/src/pycityvisitorparking/provider/demo/__init__.py
@@ -1,0 +1,263 @@
+"""Demo provider — returns hardcoded mock data, no network calls."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from datetime import datetime
+
+from ...models import Favorite, Permit, Reservation, ZoneValidityBlock
+from ..base import BaseProvider
+
+_FAVORITES_BY_CITY: dict[str, list[dict[str, str]]] = {
+    "groningen": [
+        {"id": "g1", "name": "Jan de Vries", "license_plate": "GN-24-XR"},
+        {"id": "g2", "name": "Sophie Bakker", "license_plate": "TZ-881-V"},
+        {"id": "g3", "name": "Lucas Dijkstra", "license_plate": "KL-55-BN"},
+        {"id": "g4", "name": "Emma Hoffmann", "license_plate": "RX-19-ZT"},
+        {"id": "g5", "name": "Noor van den Berg", "license_plate": "GH-072-K"},
+        {"id": "g6", "name": "Thomas Mulder", "license_plate": "VB-334-J"},
+        {"id": "g7", "name": "Roos Smit", "license_plate": "NP-61-GW"},
+        {"id": "g8", "name": "Kevin Brouwer", "license_plate": "LS-48-FD"},
+        {"id": "g9", "name": "Anouk Visser", "license_plate": "DP-909-X"},
+        {"id": "g10", "name": "Daan Hendriks", "license_plate": "QT-77-MN"},
+    ],
+    "den haag": [
+        {"id": "h1", "name": "Pieter de Groot", "license_plate": "SH-321-R"},
+        {"id": "h2", "name": "Lena Jansen", "license_plate": "BK-06-WZ"},
+        {"id": "h3", "name": "Fatima el-Amin", "license_plate": "ZG-188-P"},
+        {"id": "h4", "name": "Boris Kuiper", "license_plate": "FK-867-T"},
+        {"id": "h5", "name": "Mila Fonteijn", "license_plate": "PR-53-XJ"},
+    ],
+    "eindhoven": [
+        {"id": "e1", "name": "Lars Martens", "license_plate": "EV-112-B"},
+        {"id": "e2", "name": "Charlotte Prins", "license_plate": "HD-77-RP"},
+        {"id": "e3", "name": "Naomi Scholten", "license_plate": "WL-84-GF"},
+        {"id": "e4", "name": "Dylan Aerts", "license_plate": "NG-66-CT"},
+        {"id": "e5", "name": "Zoë Hermans", "license_plate": "KV-43-WM"},
+        {"id": "e6", "name": "Robin Claes", "license_plate": "PF-812-S"},
+        {"id": "e7", "name": "Fleur Verstegen", "license_plate": "TX-37-HN"},
+    ],
+    "default": [
+        {"id": "d1", "name": "Demo Gebruiker", "license_plate": "XX-000-X"},
+    ],
+}
+
+_RESERVATIONS: list[dict[str, str]] = [
+    {
+        "id": "res-1",
+        "name": "Sophie Bakker",
+        "license_plate": "TZ-881-V",
+        "start_time": "2026-04-15T08:30:00+00:00",
+        "end_time": "2026-04-15T14:00:00+00:00",
+    },
+    {
+        "id": "res-2",
+        "name": "Fatima el-Amin",
+        "license_plate": "ZG-188-P",
+        "start_time": "2026-04-15T10:00:00+00:00",
+        "end_time": "2026-04-15T18:00:00+00:00",
+    },
+    {
+        "id": "res-3",
+        "name": "Dylan Aerts",
+        "license_plate": "NG-66-CT",
+        "start_time": "2026-04-15T09:15:00+00:00",
+        "end_time": "2026-04-15T12:30:00+00:00",
+    },
+]
+
+
+class Provider(BaseProvider):
+    """Demo provider that returns hardcoded data without making network requests."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        self._favorites: list[dict[str, str]] | None = None
+        self._reservations: list[dict[str, str]] = [dict(r) for r in _RESERVATIONS]
+
+    def _get_favorites(self) -> list[dict[str, str]]:
+        """Lazy-initialize favorites so the city context is available."""
+        if self._favorites is None:
+            city = (self._request_context_name or "").lower()
+            source = next(
+                (favs for key, favs in _FAVORITES_BY_CITY.items() if key in city),
+                _FAVORITES_BY_CITY["default"],
+            )
+            self._favorites = [dict(f) for f in source]
+        return self._favorites
+
+    async def login(
+        self,
+        credentials: Mapping[str, object] | None = None,
+        **kwargs: object,
+    ) -> None:
+        """No-op — demo provider needs no authentication."""
+
+    def _demo_permit_config(self) -> dict:
+        """Return per-city permit configuration based on municipality name."""
+        city = (self._request_context_name or "").lower()
+        if "groningen" in city:
+            return {
+                "remaining_balance": 237.50,
+                "balance_unit": "EURO",
+                "zone_start": "2026-04-15T08:00:00+00:00",
+                "zone_end": "2026-04-15T20:00:00+00:00",
+            }
+        if "den haag" in city or "haag" in city:
+            return {
+                "remaining_balance": 480,
+                "balance_unit": "MINUTE",
+                "zone_start": "2026-04-15T09:00:00+00:00",
+                "zone_end": "2026-04-15T23:00:00+00:00",
+            }
+        if "eindhoven" in city:
+            return {
+                "remaining_balance": 12.75,
+                "balance_unit": "EURO",
+                "zone_start": "2026-04-15T07:30:00+00:00",
+                "zone_end": "2026-04-15T18:30:00+00:00",
+            }
+        # fallback
+        return {
+            "remaining_balance": 100.0,
+            "balance_unit": "EURO",
+            "zone_start": "2026-04-15T08:00:00+00:00",
+            "zone_end": "2026-04-15T20:00:00+00:00",
+        }
+
+    async def get_permit(self) -> Permit:
+        cfg = self._demo_permit_config()
+        return Permit(
+            id="demo-permit",
+            remaining_balance=cfg["remaining_balance"],
+            balance_unit=cfg["balance_unit"],
+            zone_validity=[
+                ZoneValidityBlock(
+                    start_time=cfg["zone_start"],
+                    end_time=cfg["zone_end"],
+                )
+            ],
+        )
+
+    async def list_reservations(self) -> list[Reservation]:
+        return [
+            Reservation(
+                id=r["id"],
+                name=r["name"],
+                license_plate=r["license_plate"],
+                start_time=r["start_time"],
+                end_time=r["end_time"],
+            )
+            for r in self._reservations
+        ]
+
+    async def start_reservation(
+        self,
+        license_plate: str,
+        start_time: datetime,
+        end_time: datetime,
+        name: str | None = None,
+    ) -> Reservation:
+        reservation = Reservation(
+            id=str(uuid.uuid4()),
+            name=name or "",
+            license_plate=license_plate,
+            start_time=self._format_utc_timestamp(self._normalize_datetime(start_time)),
+            end_time=self._format_utc_timestamp(self._normalize_datetime(end_time)),
+        )
+        self._reservations.append(
+            {
+                "id": reservation.id,
+                "name": reservation.name,
+                "license_plate": reservation.license_plate,
+                "start_time": reservation.start_time,
+                "end_time": reservation.end_time,
+            }
+        )
+        return reservation
+
+    async def update_reservation(
+        self,
+        reservation_id: str,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        name: str | None = None,
+    ) -> Reservation:
+        for r in self._reservations:
+            if r["id"] == reservation_id:
+                if start_time is not None:
+                    r["start_time"] = self._format_utc_timestamp(
+                        self._normalize_datetime(start_time)
+                    )
+                if end_time is not None:
+                    r["end_time"] = self._format_utc_timestamp(self._normalize_datetime(end_time))
+                if name is not None:
+                    r["name"] = name
+                return Reservation(
+                    id=r["id"],
+                    name=r["name"],
+                    license_plate=r["license_plate"],
+                    start_time=r["start_time"],
+                    end_time=r["end_time"],
+                )
+        from ...exceptions import ProviderError
+
+        raise ProviderError(f"Reservation {reservation_id!r} not found.")
+
+    async def end_reservation(
+        self,
+        reservation_id: str,
+        end_time: datetime,
+    ) -> Reservation:
+        for i, r in enumerate(self._reservations):
+            if r["id"] == reservation_id:
+                ended = Reservation(
+                    id=r["id"],
+                    name=r["name"],
+                    license_plate=r["license_plate"],
+                    start_time=r["start_time"],
+                    end_time=self._format_utc_timestamp(self._normalize_datetime(end_time)),
+                )
+                self._reservations.pop(i)
+                return ended
+        from ...exceptions import ProviderError
+
+        raise ProviderError(f"Reservation {reservation_id!r} not found.")
+
+    async def list_favorites(self) -> list[Favorite]:
+        return [
+            Favorite(id=f["id"], name=f["name"], license_plate=f["license_plate"])
+            for f in self._get_favorites()
+        ]
+
+    async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
+        favorite = Favorite(
+            id=str(uuid.uuid4()),
+            name=name or "",
+            license_plate=license_plate,
+        )
+        self._get_favorites().append(
+            {"id": favorite.id, "name": favorite.name, "license_plate": favorite.license_plate}
+        )
+        return favorite
+
+    async def _update_favorite_native(
+        self,
+        favorite_id: str,
+        license_plate: str | None = None,
+        name: str | None = None,
+    ) -> Favorite:
+        for f in self._get_favorites():
+            if f["id"] == favorite_id:
+                if license_plate is not None:
+                    f["license_plate"] = license_plate
+                if name is not None:
+                    f["name"] = name
+                return Favorite(id=f["id"], name=f["name"], license_plate=f["license_plate"])
+        from ...exceptions import ProviderError
+
+        raise ProviderError(f"Favorite {favorite_id!r} not found.")
+
+    async def remove_favorite(self, favorite_id: str) -> None:
+        self._favorites = [f for f in self._get_favorites() if f["id"] != favorite_id]

--- a/src/pycityvisitorparking/provider/demo/__init__.py
+++ b/src/pycityvisitorparking/provider/demo/__init__.py
@@ -160,6 +160,9 @@ class Provider(BaseProvider):
         end_time: datetime,
         name: str | None = None,
     ) -> Reservation:
+        start_time, end_time = self._validate_reservation_times(
+            start_time, end_time, require_both=True
+        )
         reservation = Reservation(
             id=str(uuid.uuid4()),
             name=name or "",
@@ -229,10 +232,11 @@ class Provider(BaseProvider):
         ]
 
     async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
+        normalized = self._normalize_license_plate(license_plate)
         favorite = Favorite(
-            id=str(uuid.uuid4()),
+            id=normalized,
             name=name or "",
-            license_plate=license_plate,
+            license_plate=normalized,
         )
         self._get_favorites().append(
             {"id": favorite.id, "name": favorite.name, "license_plate": favorite.license_plate}
@@ -248,7 +252,7 @@ class Provider(BaseProvider):
         for f in self._get_favorites():
             if f["id"] == favorite_id:
                 if license_plate is not None:
-                    f["license_plate"] = license_plate
+                    f["license_plate"] = self._normalize_license_plate(license_plate)
                 if name is not None:
                     f["name"] = name
                 return Favorite(id=f["id"], name=f["name"], license_plate=f["license_plate"])

--- a/src/pycityvisitorparking/provider/demo/__init__.py
+++ b/src/pycityvisitorparking/provider/demo/__init__.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Mapping
 from datetime import datetime
 
+from ...exceptions import ProviderError
 from ...models import Favorite, Permit, Reservation, ZoneValidityBlock
 from ..base import BaseProvider
 
@@ -201,8 +202,6 @@ class Provider(BaseProvider):
                     start_time=r["start_time"],
                     end_time=r["end_time"],
                 )
-        from ...exceptions import ProviderError
-
         raise ProviderError(f"Reservation {reservation_id!r} not found.")
 
     async def end_reservation(
@@ -221,8 +220,6 @@ class Provider(BaseProvider):
                 )
                 self._reservations.pop(i)
                 return ended
-        from ...exceptions import ProviderError
-
         raise ProviderError(f"Reservation {reservation_id!r} not found.")
 
     async def list_favorites(self) -> list[Favorite]:
@@ -255,8 +252,6 @@ class Provider(BaseProvider):
                 if name is not None:
                     f["name"] = name
                 return Favorite(id=f["id"], name=f["name"], license_plate=f["license_plate"])
-        from ...exceptions import ProviderError
-
         raise ProviderError(f"Favorite {favorite_id!r} not found.")
 
     async def remove_favorite(self, favorite_id: str) -> None:

--- a/src/pycityvisitorparking/provider/demo/manifest.json
+++ b/src/pycityvisitorparking/provider/demo/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id": "demo",
+  "name": "Demo",
+  "capabilities": {
+    "favorite_update_fields": ["license_plate", "name"],
+    "reservation_update_fields": ["start_time", "end_time"],
+    "balance_units": ["EURO"]
+  }
+}

--- a/src/pycityvisitorparking/provider/demo/manifest.json
+++ b/src/pycityvisitorparking/provider/demo/manifest.json
@@ -4,6 +4,6 @@
   "capabilities": {
     "favorite_update_fields": ["license_plate", "name"],
     "reservation_update_fields": ["start_time", "end_time"],
-    "balance_units": ["EURO"]
+    "balance_units": ["EURO", "MINUTE"]
   }
 }

--- a/src/pycityvisitorparking/provider/dvsportal/api.py
+++ b/src/pycityvisitorparking/provider/dvsportal/api.py
@@ -350,6 +350,21 @@ class Provider(BaseProvider):
             self._log_operation_completed("list_favorites", count=len(favorites))
             return favorites
 
+    async def fetch_all(self) -> tuple[Permit, list[Reservation], list[Favorite]]:
+        """Return permit, reservations, and favorites with a single provider fetch."""
+        async with self._operation_guard():
+            self._log_operation_started("fetch_all")
+            permit_raw = await self._fetch_base(operation="fetch_all")
+            permit = self._mapper.map_permit(permit_raw)
+            reservations = self._mapper.reservations_from_permit(permit_raw)
+            favorites = self._mapper.favorites_from_permit(permit_raw)
+            self._log_operation_completed(
+                "fetch_all",
+                reservations=len(reservations),
+                favorites=len(favorites),
+            )
+            return permit, reservations, favorites
+
     async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
         """Add a favorite."""
         async with self._operation_guard():

--- a/src/pycityvisitorparking/provider/dvsportal/tests/test_provider.py
+++ b/src/pycityvisitorparking/provider/dvsportal/tests/test_provider.py
@@ -975,3 +975,28 @@ async def test_fetch_app_env_sets_flag_on_success(
         await provider._transport.fetch_app_env()
 
     assert provider._transport._state.app_env_fetched
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_uses_single_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with aiohttp.ClientSession() as session:
+        provider = Provider(session, _manifest(), base_url="https://example")
+        fetch_base_calls = {"count": 0}
+
+        async def _fake_fetch_base(*, operation: str = "fetch_base") -> dict[str, Any]:
+            fetch_base_calls["count"] += 1
+            return PERMIT_SAMPLE
+
+        monkeypatch.setattr(provider, "_fetch_base", _fake_fetch_base)
+
+        permit, reservations, favorites = await provider.fetch_all()
+
+    assert fetch_base_calls["count"] == 1
+    assert permit.id == "CARD-1"
+    assert permit.remaining_balance == 120
+    assert len(reservations) == 1
+    assert reservations[0].id == "123"
+    assert len(favorites) == 1
+    assert favorites[0].id == "XY99ZZ"

--- a/tests/test_2park_api.py
+++ b/tests/test_2park_api.py
@@ -592,6 +592,41 @@ async def test_http_500_raises_provider_error() -> None:
         await provider.get_permit()
 
 
+# --- fetch_all ---
+
+
+async def test_fetch_all_uses_two_parallel_requests() -> None:
+    provider, session = await _logged_in_provider(
+        [
+            _FakeResponse(json_data=_AUTH_OK),
+            _FakeResponse(json_data=_CATEGORIES),
+            _FakeResponse(json_data=_BALANCE),
+            _FakeResponse(json_data=_PRODUCT_DETAILS_WITH_MEMBERS),
+        ]
+    )
+    permit, reservations, _favorites = await provider.fetch_all()
+    # Two HTTP requests: BALANCE_ENDPOINT + PRODUCT_DETAILS_ENDPOINT
+    assert session.calls == 4  # 2 login + 2 fetch_all
+    assert permit.remaining_balance == 120
+    assert len(reservations) == 1
+    assert reservations[0].license_plate == "AB1234"
+
+
+async def test_fetch_all_empty_details() -> None:
+    provider, _session = await _logged_in_provider(
+        [
+            _FakeResponse(json_data=_AUTH_OK),
+            _FakeResponse(json_data=_CATEGORIES),
+            _FakeResponse(json_data=_BALANCE),
+            _FakeResponse(json_data=_PRODUCT_DETAILS_EMPTY),
+        ]
+    )
+    permit, reservations, favorites = await provider.fetch_all()
+    assert permit.balance_unit == "MINUTE"
+    assert reservations == []
+    assert favorites == []
+
+
 # --- mapping unit tests ---
 # (kept here because "2park" is not a valid Python identifier so pytest cannot
 # traverse src/pycityvisitorparking/provider/2park/ for test collection)

--- a/tests/test_base_provider.py
+++ b/tests/test_base_provider.py
@@ -381,6 +381,15 @@ async def test_request_text_provider_error() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status", [502, 503, 504])
+async def test_request_text_network_error_on_gateway_timeout(status: int) -> None:
+    session = _SequenceSession([_FakeResponse(status=status)])
+    provider = _DummyProvider(session, _manifest(), base_url="https://example.com")
+    with pytest.raises(NetworkError):
+        await provider._request_text("GET", "/path")
+
+
+@pytest.mark.asyncio
 async def test_request_text_success() -> None:
     session = _SequenceSession([_FakeResponse(text_data="ok")])
     provider = _DummyProvider(session, _manifest(), base_url="https://example.com")

--- a/tests/test_base_provider.py
+++ b/tests/test_base_provider.py
@@ -396,6 +396,15 @@ async def test_request_text_success() -> None:
     assert await provider._request_text("GET", "/path") == "ok"
 
 
+@pytest.mark.asyncio
+async def test_fetch_all_default_returns_permit_reservations_favorites() -> None:
+    provider = _DummyProvider(_SequenceSession([]), _manifest(), base_url="https://example.com")
+    permit, reservations, favorites = await provider.fetch_all()
+    assert permit.id == "permit"
+    assert reservations == []
+    assert favorites == []
+
+
 def test_validate_reservation_times_require_both() -> None:
     provider = _DummyProvider(_SequenceSession([]), _manifest(), base_url="https://example.com")
     start = datetime(2024, 1, 1, 10, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary

- **`fetch_all()` on BaseProvider**: new method that returns `(Permit, list[Reservation], list[Favorite])` in one call. Default implementation uses `asyncio.gather` on the three existing methods. This is the method the HA coordinator now calls instead of three separate requests
- **2park override**: fetches `BALANCE_ENDPOINT` and `PRODUCT_DETAILS_ENDPOINT` in parallel (2 requests → 1 gather), then maps all three results from the responses in one pass
- **dvsportal override**: true single-request implementation — reuses `_fetch_base()` and maps permit, reservations, and favorites from the one HTTP response
- **502/503/504 → `NetworkError`**: gateway errors are now treated as transient network failures so the HA coordinator retries, rather than `ProviderError` which causes a fault
- **Per-instance logger**: all `_LOGGER` calls in `BaseProvider` replaced with `self._logger` (`get_provider_logger`) for better per-provider log filtering
- **Demo provider**: new `provider/demo/` with hardcoded mock data for Den Haag (MINUTE balance), Eindhoven (EURO), and Groningen (EURO) — no network calls, intended for UI development and integration testing

## Test plan

- [ ] All pre-commit hooks pass (ruff, pyright, pytest)
- [ ] `test_request_text_network_error_on_gateway_timeout` passes for 502, 503, 504
- [ ] Verify 2park `fetch_all` uses 2 parallel requests (check logs)
- [ ] Verify dvsportal `fetch_all` uses 1 request (check logs)
- [ ] Demo provider returns correct city-specific data without network calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)