### PR TITLE
fix: normalize license plates, UTC Z timestamps, time ordering in demo provider

### DIFF
--- a/src/pycityvisitorparking/provider/demo/__init__.py
+++ b/src/pycityvisitorparking/provider/demo/__init__.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from ...exceptions import ProviderError
 from ...models import Favorite, Permit, Reservation, ZoneValidityBlock
+from ...util import parse_timestamp
 from ..base import BaseProvider
 
 _FAVORITES_BY_CITY: dict[str, list[dict[str, str]]] = {
@@ -48,23 +49,23 @@ _RESERVATIONS: list[dict[str, str]] = [
     {
         "id": "res-1",
         "name": "Sophie Bakker",
-        "license_plate": "TZ-881-V",
-        "start_time": "2026-04-15T08:30:00+00:00",
-        "end_time": "2026-04-15T14:00:00+00:00",
+        "license_plate": "TZ881V",
+        "start_time": "2026-04-15T08:30:00Z",
+        "end_time": "2026-04-15T14:00:00Z",
     },
     {
         "id": "res-2",
         "name": "Fatima el-Amin",
-        "license_plate": "ZG-188-P",
-        "start_time": "2026-04-15T10:00:00+00:00",
-        "end_time": "2026-04-15T18:00:00+00:00",
+        "license_plate": "ZG188P",
+        "start_time": "2026-04-15T10:00:00Z",
+        "end_time": "2026-04-15T18:00:00Z",
     },
     {
         "id": "res-3",
         "name": "Dylan Aerts",
-        "license_plate": "NG-66-CT",
-        "start_time": "2026-04-15T09:15:00+00:00",
-        "end_time": "2026-04-15T12:30:00+00:00",
+        "license_plate": "NG66CT",
+        "start_time": "2026-04-15T09:15:00Z",
+        "end_time": "2026-04-15T12:30:00Z",
     },
 ]
 
@@ -102,29 +103,29 @@ class Provider(BaseProvider):
             return {
                 "remaining_balance": 237.50,
                 "balance_unit": "EURO",
-                "zone_start": "2026-04-15T08:00:00+00:00",
-                "zone_end": "2026-04-15T20:00:00+00:00",
+                "zone_start": "2026-04-15T08:00:00Z",
+                "zone_end": "2026-04-15T20:00:00Z",
             }
         if "den haag" in city or "haag" in city:
             return {
                 "remaining_balance": 480,
                 "balance_unit": "MINUTE",
-                "zone_start": "2026-04-15T09:00:00+00:00",
-                "zone_end": "2026-04-15T23:00:00+00:00",
+                "zone_start": "2026-04-15T09:00:00Z",
+                "zone_end": "2026-04-15T23:00:00Z",
             }
         if "eindhoven" in city:
             return {
                 "remaining_balance": 12.75,
                 "balance_unit": "EURO",
-                "zone_start": "2026-04-15T07:30:00+00:00",
-                "zone_end": "2026-04-15T18:30:00+00:00",
+                "zone_start": "2026-04-15T07:30:00Z",
+                "zone_end": "2026-04-15T18:30:00Z",
             }
         # fallback
         return {
             "remaining_balance": 100.0,
             "balance_unit": "EURO",
-            "zone_start": "2026-04-15T08:00:00+00:00",
-            "zone_end": "2026-04-15T20:00:00+00:00",
+            "zone_start": "2026-04-15T08:00:00Z",
+            "zone_end": "2026-04-15T20:00:00Z",
         }
 
     async def get_permit(self) -> Permit:
@@ -146,7 +147,7 @@ class Provider(BaseProvider):
             Reservation(
                 id=r["id"],
                 name=r["name"],
-                license_plate=r["license_plate"],
+                license_plate=self._normalize_license_plate(r["license_plate"]),
                 start_time=r["start_time"],
                 end_time=r["end_time"],
             )
@@ -166,7 +167,7 @@ class Provider(BaseProvider):
         reservation = Reservation(
             id=str(uuid.uuid4()),
             name=name or "",
-            license_plate=license_plate,
+            license_plate=self._normalize_license_plate(license_plate),
             start_time=self._format_utc_timestamp(self._normalize_datetime(start_time)),
             end_time=self._format_utc_timestamp(self._normalize_datetime(end_time)),
         )
@@ -190,12 +191,19 @@ class Provider(BaseProvider):
     ) -> Reservation:
         for r in self._reservations:
             if r["id"] == reservation_id:
-                if start_time is not None:
-                    r["start_time"] = self._format_utc_timestamp(
-                        self._normalize_datetime(start_time)
-                    )
-                if end_time is not None:
-                    r["end_time"] = self._format_utc_timestamp(self._normalize_datetime(end_time))
+                effective_start = (
+                    self._normalize_datetime(start_time)
+                    if start_time is not None
+                    else parse_timestamp(r["start_time"])
+                )
+                effective_end = (
+                    self._normalize_datetime(end_time)
+                    if end_time is not None
+                    else parse_timestamp(r["end_time"])
+                )
+                self._validate_reservation_times(effective_start, effective_end, require_both=True)
+                r["start_time"] = self._format_utc_timestamp(effective_start)
+                r["end_time"] = self._format_utc_timestamp(effective_end)
                 if name is not None:
                     r["name"] = name
                 return Reservation(


### PR DESCRIPTION
## Summary

- `list_reservations()` and `start_reservation()` now normalize license plates via `_normalize_license_plate()`
- Hardcoded timestamps in `_RESERVATIONS` and `_demo_permit_config()` changed from `+00:00` to `Z` format
- `update_reservation()` validates that effective end time is after start time before persisting

Closes review feedback from sir-Unknown/pyCityVisitorParking#46 (review 4123812298).

🤖 Generated with [Claude Code](https://claude.com/claude-code)