### PR TITLE
fix: expand pytest testpaths to include src/ for provider test discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,6 @@ max-line-length-suggestions = 72
 # Pytest configuration
 # ----------------------------
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 asyncio_mode = "auto"
 addopts = "-q --cov=pycityvisitorparking --cov-report=term:skip-covered"


### PR DESCRIPTION
## Summary

- `testpaths` in `pyproject.toml` extended from `["tests"]` to `["tests", "src"]`
- Dvsportal tests in `src/pycityvisitorparking/provider/dvsportal/tests/` are now discovered and run in CI

Closes review feedback from sir-Unknown/pyCityVisitorParking#41 (discussion r3071749068).

🤖 Generated with [Claude Code](https://claude.com/claude-code)