### PR TITLE
refactor: introduce ProviderLogger and remove delegate wrappers

### DIFF
--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -80,7 +80,7 @@ class Provider(BaseProvider):
         **kwargs: object,
     ) -> None:
         """Authenticate against the provider."""
-        self._log_operation_started("login")
+        self._plogger.operation_started("login")
         merged = self._merge_credentials(credentials, **kwargs)
         username = merged.get("username")
         password = merged.get("password")
@@ -113,26 +113,26 @@ class Provider(BaseProvider):
             self._credentials["product_id"] = product_id
         if location:
             self._credentials["location"] = location
-        self._log_operation_completed("login", product_id=product_id, location=location)
+        self._plogger.operation_completed("login", product_id=product_id, location=location)
 
     async def get_permit(self) -> Permit:
         """Return the active permit for the account."""
-        self._log_operation_started("get_permit")
+        self._plogger.operation_started("get_permit")
         await self._ensure_authenticated()
         data = await self._post_form(
             BALANCE_ENDPOINT,
             {"product_id": self._product_id or "", "locale": LOCALE},
         )
         permit = self._map_permit(data)
-        self._log_operation_completed("get_permit")
+        self._plogger.operation_completed("get_permit")
         return permit
 
     async def list_reservations(self) -> list[Reservation]:
         """Return active reservations."""
-        self._log_operation_started("list_reservations")
+        self._plogger.operation_started("list_reservations")
         details = await self._fetch_product_details()
         reservations = self._map_reservation_list(details)
-        self._log_operation_completed("list_reservations", count=len(reservations))
+        self._plogger.operation_completed("list_reservations", count=len(reservations))
         return reservations
 
     async def start_reservation(
@@ -143,7 +143,7 @@ class Provider(BaseProvider):
         name: str | None = None,
     ) -> Reservation:
         """Start a reservation for a license plate."""
-        self._log_operation_started("start_reservation")
+        self._plogger.operation_started("start_reservation")
         await self._ensure_authenticated()
         start_dt, end_dt = self._validate_reservation_times(start_time, end_time, require_both=True)
         normalized_plate = self._normalize_license_plate(license_plate)
@@ -188,7 +188,7 @@ class Provider(BaseProvider):
                 start_time=format_utc_timestamp(start_dt),
                 end_time=format_utc_timestamp(end_dt),
             )
-        self._log_operation_completed("start_reservation")
+        self._plogger.operation_completed("start_reservation")
         return reservation
 
     async def update_reservation(
@@ -199,7 +199,7 @@ class Provider(BaseProvider):
         name: str | None = None,
     ) -> Reservation:
         """Update a reservation end time."""
-        self._log_operation_started("update_reservation")
+        self._plogger.operation_started("update_reservation")
         if start_time is not None or name is not None:
             raise ValidationError("Only end_time can be updated.")
         if end_time is None:
@@ -232,7 +232,7 @@ class Provider(BaseProvider):
             message = data.get("status", {}).get("message", "Unknown error")
             raise ProviderError(f"Failed to update reservation: {message}")
 
-        self._log_operation_completed("update_reservation")
+        self._plogger.operation_completed("update_reservation")
         return Reservation(
             id=existing.id,
             name=existing.name,
@@ -247,7 +247,7 @@ class Provider(BaseProvider):
         end_time: datetime,
     ) -> Reservation:
         """End a reservation."""
-        self._log_operation_started("end_reservation")
+        self._plogger.operation_started("end_reservation")
         reservation_id_value = self._require_id(reservation_id, "reservation_id")
         end_dt = self._normalize_datetime(end_time)
         normalized_end_time = format_utc_timestamp(end_dt)
@@ -276,20 +276,20 @@ class Provider(BaseProvider):
             start_time=existing.start_time,
             end_time=normalized_end_time,
         )
-        self._log_operation_completed("end_reservation")
+        self._plogger.operation_completed("end_reservation")
         return reservation
 
     async def list_favorites(self) -> list[Favorite]:
         """Return stored license plates as favorites."""
-        self._log_operation_started("list_favorites")
+        self._plogger.operation_started("list_favorites")
         details = await self._fetch_product_details()
         favorites = self._map_favorite_list(details)
-        self._log_operation_completed("list_favorites", count=len(favorites))
+        self._plogger.operation_completed("list_favorites", count=len(favorites))
         return favorites
 
     async def fetch_all(self) -> tuple[Permit, list[Reservation], list[Favorite]]:
         """Return permit, reservations, and favorites with two parallel provider fetches."""
-        self._log_operation_started("fetch_all")
+        self._plogger.operation_started("fetch_all")
         await self._ensure_authenticated()
         permit_data, details = await asyncio.gather(
             self._post_form(
@@ -304,7 +304,7 @@ class Provider(BaseProvider):
         permit = self._map_permit(permit_data)
         reservations = self._map_reservation_list(details)
         favorites = self._map_favorite_list(details)
-        self._log_operation_completed(
+        self._plogger.operation_completed(
             "fetch_all",
             reservations=len(reservations),
             favorites=len(favorites),
@@ -313,11 +313,11 @@ class Provider(BaseProvider):
 
     async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
         """Add a favorite."""
-        self._log_operation_started("add_favorite")
+        self._plogger.operation_started("add_favorite")
         normalized_plate = self._normalize_license_plate(license_plate)
         for existing in await self.list_favorites():
             if existing.license_plate == normalized_plate:
-                self._log_operation_failed("add_favorite", "duplicate license_plate")
+                self._plogger.operation_failed("add_favorite", "duplicate license_plate")
                 raise ValidationError("license_plate is already a favorite.")
         name_value = name or normalized_plate
         data = await self._post_form(
@@ -347,7 +347,7 @@ class Provider(BaseProvider):
         favorite = next((f for f in favorites if f.license_plate == normalized_plate), None)
         if favorite is None:
             raise ProviderError("Favorite was not returned by the provider.")
-        self._log_operation_completed("add_favorite")
+        self._plogger.operation_completed("add_favorite")
         return favorite
 
     async def _update_favorite_native(
@@ -361,7 +361,7 @@ class Provider(BaseProvider):
 
     async def remove_favorite(self, favorite_id: str) -> None:
         """Remove a favorite."""
-        self._log_operation_started("remove_favorite")
+        self._plogger.operation_started("remove_favorite")
         favorite_id_value = self._require_id(favorite_id, "favorite_id")
 
         existing = self._find_by_id(await self.list_favorites(), favorite_id_value)
@@ -390,7 +390,7 @@ class Provider(BaseProvider):
         if major != "OK":
             message = data.get("status", {}).get("message", "Unknown error")
             raise ProviderError(f"Failed to remove favorite: {message}")
-        self._log_operation_completed("remove_favorite")
+        self._plogger.operation_completed("remove_favorite")
 
     async def _detect_product(self, product_id: str | None) -> tuple[str, str | None]:
         """Fetch categories and return (product_id, location) for the selected product."""
@@ -432,7 +432,7 @@ class Provider(BaseProvider):
         self._product_id = None
         if not self._credentials:
             raise AuthError("Authentication required.")
-        self._log_reauthenticating()
+        self._plogger.reauthenticating()
         await self.login(self._credentials)
 
     def _map_permit(self, data: Any) -> Permit:
@@ -568,17 +568,17 @@ class Provider(BaseProvider):
             _attempt: int,
             _attempts: int,
         ) -> Any:
-            self._log_response_status(response.status)
+            self._plogger.response_status(response.status)
             if response.status in (401, 403):
-                self._log_request_failure(response.status)
+                self._plogger.request_failure(response.status)
                 raise AuthError("Authentication failed.")
             if not 200 <= response.status < 300:
-                self._log_request_failure(response.status)
+                self._plogger.request_failure(response.status)
                 raise ProviderError(f"Provider request failed with status {response.status}.")
             try:
                 return await response.json(content_type=None)
             except (aiohttp.ContentTypeError, ValueError) as exc:
-                self._log_invalid_json(await response.text())
+                self._plogger.invalid_json(await response.text())
                 raise ProviderError("Response did not contain valid JSON.") from exc
 
         return await self._request_with_retries(

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -129,88 +129,6 @@ class BaseProvider(ABC):
             self._pycvp_version,
         )
 
-    # ------------------------------------------------------------------
-    # Logging delegates — logic lives in self._plogger (ProviderLogger).
-    # These wrappers keep the existing call-sites in subclasses working
-    # and will be removed once all callers are updated to use _plogger
-    # directly (see GitHub issue #53).
-    # ------------------------------------------------------------------
-
-    def _log_with_metadata(self, level: int, message: str, *args: Any) -> None:
-        self._plogger.log(level, message, *args)
-
-    def _log_warning_block(
-        self, label: str, fields: dict[str, Any], *, detail: str | None = None
-    ) -> None:
-        self._plogger.warning_block(label, fields, detail=detail)
-
-    def _log_operation_started(self, operation: str, **details: Any) -> None:
-        self._plogger.operation_started(operation, **details)
-
-    def _log_operation_completed(self, operation: str, **details: Any) -> None:
-        self._plogger.operation_completed(operation, **details)
-
-    def _log_operation_failed(self, operation: str, reason: str, **details: Any) -> None:
-        self._plogger.operation_failed(operation, reason, **details)
-
-    def _log_reauth_triggered(self) -> None:
-        self._plogger.reauth_triggered()
-
-    def _log_reauthenticating(self) -> None:
-        self._plogger.reauthenticating()
-
-    def _log_provider_error_response(
-        self, data: dict[str, Any], *, operation: str | None = None
-    ) -> None:
-        self._plogger.provider_error_response(data, operation=operation)
-
-    def _log_missing_response_data(
-        self, label: str, fallback: str = "refetching", *, response_data: Any = None
-    ) -> None:
-        self._plogger.missing_response_data(label, fallback, response_data=response_data)
-
-    def _log_response_status(self, status: int) -> None:
-        self._plogger.response_status(status)
-
-    def _log_response_summary(self, data: Any) -> None:
-        self._plogger.response_summary(data)
-
-    def _log_request_failure(
-        self,
-        status: int,
-        *,
-        method: str | None = None,
-        url: str | None = None,
-        operation: str | None = None,
-        payload: Any = None,
-        body: str | None = None,
-        content_type: str | None = None,
-    ) -> None:
-        self._plogger.request_failure(
-            status,
-            method=method,
-            url=url,
-            operation=operation,
-            payload=payload,
-            body=body,
-            content_type=content_type,
-        )
-
-    def _log_invalid_json(self, body: str) -> None:
-        self._plogger.invalid_json(body)
-
-    def _mask_payload(self, payload: Any) -> Any:
-        return self._plogger.mask_payload(payload)
-
-    def _mask_log_value(self, value: Any, *, parent_key: str | None = None) -> Any:
-        return self._plogger.mask_value(value, parent_key=parent_key)
-
-    def _summarize_log_text(self, value: str) -> str:
-        return self._plogger.summarize_text(value)
-
-    def _build_response_summary(self, data: Any) -> dict[str, Any]:
-        return self._plogger.build_response_summary(data)
-
     async def _request_with_optional_reauth(
         self,
         *,
@@ -225,7 +143,7 @@ class BaseProvider(ABC):
                 return await request()
             except AuthError:
                 if allow_reauth and attempt == 0:
-                    self._log_reauth_triggered()
+                    self._plogger.reauth_triggered()
                     if on_reauth is None:
                         raise
                     await on_reauth()
@@ -438,7 +356,7 @@ class BaseProvider(ABC):
                 continue
             except (aiohttp.ClientError, TimeoutError) as exc:
                 last_error = exc
-                self._log_warning_block("network error", {"error": exc.__class__.__name__})
+                self._plogger.warning_block("network error", {"error": exc.__class__.__name__})
                 if attempt >= attempts - 1:
                     raise NetworkError("Network request failed.") from exc
         if last_error is not None:
@@ -463,7 +381,7 @@ class BaseProvider(ABC):
             _attempt: int,
             _attempts: int,
         ) -> Any:
-            self._log_response_status(response.status)
+            self._plogger.response_status(response.status)
             if not 200 <= response.status < 300:
                 self._raise_for_status(
                     response,
@@ -478,9 +396,9 @@ class BaseProvider(ABC):
                 try:
                     data = await response.json()
                 except (aiohttp.ContentTypeError, ValueError) as exc:
-                    self._log_invalid_json(await response.text())
+                    self._plogger.invalid_json(await response.text())
                     raise ProviderError("Response did not contain valid JSON.") from exc
-                self._log_response_summary(data)
+                self._plogger.response_summary(data)
                 return data
             return await response.text()
 
@@ -504,7 +422,7 @@ class BaseProvider(ABC):
     ) -> None:
         if 200 <= response.status < 300:
             return
-        self._log_request_failure(
+        self._plogger.request_failure(
             response.status,
             method=method,
             url=url,
@@ -616,7 +534,7 @@ class BaseProvider(ABC):
             raise ValidationError("license_plate updates are not supported.")
         if name is not None and "name" not in self.favorite_update_fields:
             raise ValidationError("name updates are not supported.")
-        self._log_operation_started("update_favorite")
+        self._plogger.operation_started("update_favorite")
         return await self._update_favorite_native(
             favorite_id,
             license_plate=license_plate,

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import datetime
@@ -24,35 +23,9 @@ from ..util import (
     validate_reservation_times,
 )
 from .loader import ProviderManifest
-from .logger import get_provider_logger
+from .logger import ProviderLogger, get_provider_logger
 
 _DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=30)
-_MAX_LOG_BODY_CHARS = 600
-_HTML_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
-_HTML_BASE_RE = re.compile(
-    r"""<base[^>]+href\s*=\s*["']?([^"'\s>]+)""",
-    re.IGNORECASE | re.DOTALL,
-)
-_SENSITIVE_KEYS = frozenset(
-    {
-        "Authorization",
-        "Token",
-        "asIdentifier",
-        "identifier",
-        "otp",
-        "password",
-        "permitId",
-        "permitMediaCode",
-        "permit_id",
-        "permit_media_code",
-        "resetCode",
-        "token",
-        "username",
-        "zipCode",
-    }
-)
-_SENSITIVE_OBJECT_KEYS = frozenset({"LicensePlate", "licensePlate", "updateLicensePlate"})
-_SENSITIVE_NESTED_KEYS = frozenset({"DisplayValue", "Name", "Value"})
 _T = TypeVar("_T")
 
 try:
@@ -96,10 +69,12 @@ class BaseProvider(ABC):
         self._request_context_name: str | None = None
         self._ha_cvp_version = "unknown"
         self._pycvp_version = PACKAGE_VERSION
-        self._logger = get_provider_logger(type(self).__module__)
-        self._logger.debug(
-            "Provider %s initialized base_url=%s api_uri=%s",
-            self._manifest.id,
+        self._plogger = ProviderLogger(
+            get_provider_logger(type(self).__module__),
+            self._request_log_metadata,
+        )
+        self._plogger.debug(
+            "initialized base_url=%s api_uri=%s",
             self._base_url,
             self._api_uri or "(none)",
         )
@@ -154,208 +129,51 @@ class BaseProvider(ABC):
             self._pycvp_version,
         )
 
+    # ------------------------------------------------------------------
+    # Logging delegates — logic lives in self._plogger (ProviderLogger).
+    # These wrappers keep the existing call-sites in subclasses working
+    # and will be removed once all callers are updated to use _plogger
+    # directly (see GitHub issue #53).
+    # ------------------------------------------------------------------
+
     def _log_with_metadata(self, level: int, message: str, *args: Any) -> None:
-        """Log a message with the standard provider metadata suffix."""
-        provider, city, ha_cvp, pycvp = self._request_log_metadata()
-        self._logger.log(
-            level,
-            f"{message} (provider=%s, city=%s, hacvp=%s, pycvp=%s)",
-            *args,
-            provider,
-            city,
-            ha_cvp,
-            pycvp,
-        )
+        self._plogger.log(level, message, *args)
 
     def _log_warning_block(
-        self,
-        label: str,
-        fields: dict[str, Any],
-        *,
-        detail: str | None = None,
+        self, label: str, fields: dict[str, Any], *, detail: str | None = None
     ) -> None:
-        """Log a warning as a labelled multi-line key=value block with provider metadata."""
-        provider, city, ha_cvp, pycvp = self._request_log_metadata()
-        all_fields = {k: v for k, v in fields.items() if v is not None}
-        all_fields.update({"provider": provider, "city": city, "hacvp": ha_cvp, "pycvp": pycvp})
-        width = max(len(k) for k in all_fields)
-        lines = [label]
-        if detail:
-            lines.append(f"  {detail}")
-        for key, value in all_fields.items():
-            lines.append(f"  {key:<{width}} = {value}")
-        self._logger.warning("%s", "\n".join(lines))
-
-    def _format_log_details(self, **details: Any) -> str:
-        """Serialize optional log details as a compact key=value suffix."""
-        if not details:
-            return ""
-        return " " + " ".join(f"{key}={value}" for key, value in details.items())
+        self._plogger.warning_block(label, fields, detail=detail)
 
     def _log_operation_started(self, operation: str, **details: Any) -> None:
-        """Log the start of a provider operation."""
-        self._logger.debug(
-            "Provider %s %s started%s",
-            self.provider_id,
-            operation,
-            self._format_log_details(**details),
-        )
+        self._plogger.operation_started(operation, **details)
 
     def _log_operation_completed(self, operation: str, **details: Any) -> None:
-        """Log successful completion of a provider operation."""
-        self._logger.debug(
-            "Provider %s %s completed%s",
-            self.provider_id,
-            operation,
-            self._format_log_details(**details),
-        )
+        self._plogger.operation_completed(operation, **details)
 
     def _log_operation_failed(self, operation: str, reason: str, **details: Any) -> None:
-        """Log a provider operation failure before raising a validation/provider error."""
-        self._logger.debug(
-            "Provider %s %s failed: %s%s",
-            self.provider_id,
-            operation,
-            reason,
-            self._format_log_details(**details),
-        )
+        self._plogger.operation_failed(operation, reason, **details)
 
     def _log_reauth_triggered(self) -> None:
-        """Log when a provider request falls back to reauthentication."""
-        self._log_warning_block("reauth triggered", {})
+        self._plogger.reauth_triggered()
 
     def _log_reauthenticating(self) -> None:
-        """Log when cached credentials are used to reauthenticate."""
-        self._logger.debug(
-            "Provider %s reauthenticating with cached credentials",
-            self.provider_id,
-        )
+        self._plogger.reauthenticating()
 
-    def _log_missing_response_data(self, label: str, fallback: str = "refetching") -> None:
-        """Log when a response is missing expected data and a fallback is used."""
-        self._log_warning_block(
-            "missing permit in response", {"operation": label, "fallback": fallback}
-        )
+    def _log_provider_error_response(
+        self, data: dict[str, Any], *, operation: str | None = None
+    ) -> None:
+        self._plogger.provider_error_response(data, operation=operation)
+
+    def _log_missing_response_data(
+        self, label: str, fallback: str = "refetching", *, response_data: Any = None
+    ) -> None:
+        self._plogger.missing_response_data(label, fallback, response_data=response_data)
 
     def _log_response_status(self, status: int) -> None:
-        """Log the HTTP response status returned by a provider."""
-        self._logger.debug("Provider %s response status=%s", self.provider_id, status)
-
-    def _summarize_log_text(self, value: str) -> str:
-        """Normalize and truncate response text for safe logging."""
-        compact = " ".join(value.split())
-        if len(compact) > _MAX_LOG_BODY_CHARS:
-            return compact[: _MAX_LOG_BODY_CHARS - 3] + "..."
-        return compact
-
-    def _response_kind(self, content_type: str | None, body: str | None) -> str:
-        """Classify a failed response body for compact diagnostics."""
-        if not body:
-            return "empty"
-
-        lowered_type = (content_type or "").lower()
-        if "html" in lowered_type:
-            return "html"
-
-        compact = body.lstrip().lower()
-        if compact.startswith("<!doctype html") or compact.startswith("<html"):
-            return "html"
-
-        return "text"
-
-    def _extract_html_log_fields(self, body: str) -> dict[str, str]:
-        """Return compact HTML diagnostics without logging the full page body."""
-        fields: dict[str, str] = {}
-
-        title_match = _HTML_TITLE_RE.search(body)
-        if title_match:
-            title = self._summarize_log_text(title_match.group(1))
-            if title:
-                fields["html_title"] = title
-
-        base_match = _HTML_BASE_RE.search(body)
-        if base_match:
-            base_href = self._summarize_log_text(base_match.group(1))
-            if base_href:
-                fields["html_base_href"] = base_href
-
-        if not fields:
-            fields["body_excerpt"] = self._summarize_log_text(body)
-
-        return fields
-
-    def _mask_payload(self, payload: Any) -> Any:
-        """Return a copy of payload with sensitive values replaced by '***'."""
-        return self._mask_log_value(payload)
-
-    def _mask_log_value(self, value: Any, *, parent_key: str | None = None) -> Any:
-        """Return a masked copy of structured log data."""
-        if parent_key in _SENSITIVE_KEYS:
-            return "***" if value is not None else None
-        if isinstance(value, dict):
-            return {
-                key: (
-                    "***" if key in _SENSITIVE_KEYS else self._mask_log_value(item, parent_key=key)
-                )
-                for key, item in value.items()
-            }
-        if isinstance(value, list):
-            return [self._mask_log_value(item, parent_key=parent_key) for item in value]
-        if parent_key in _SENSITIVE_OBJECT_KEYS:
-            return "***" if value is not None else None
-        if parent_key in _SENSITIVE_NESTED_KEYS:
-            return "***" if value is not None else None
-        return value
-
-    def _response_keys_summary(self, data: dict[str, Any]) -> str:
-        """Return a compact summary of top-level response keys."""
-        keys = sorted(str(key) for key in data)
-        if len(keys) > 12:
-            return ", ".join(keys[:12]) + ", ..."
-        return ", ".join(keys)
-
-    def _build_response_summary(self, data: Any) -> dict[str, Any]:
-        """Return a safe summary of provider response structure and metadata."""
-        if isinstance(data, dict):
-            summary: dict[str, Any] = {
-                "response-type": "dict",
-                "response-keys": self._response_keys_summary(data),
-            }
-            if "Result" in data:
-                summary["result"] = data.get("Result")
-            if "LoginStatus" in data:
-                summary["login-status"] = data.get("LoginStatus")
-            if "RequiresOtp" in data:
-                summary["requires-otp"] = data.get("RequiresOtp")
-            if "Redirect" in data:
-                summary["redirect"] = data.get("Redirect")
-            if "ErrorMessage" in data and data.get("ErrorMessage"):
-                summary["error-message"] = self._summarize_log_text(str(data["ErrorMessage"]))
-            if "Token" in data:
-                summary["token-present"] = bool(data.get("Token"))
-            if "Permit" in data:
-                summary["has-permit"] = isinstance(data.get("Permit"), dict)
-            permits = data.get("Permits")
-            if isinstance(permits, list):
-                summary["permits-count"] = len(permits)
-            permit_medias = data.get("PermitMedias")
-            if isinstance(permit_medias, list):
-                summary["permit-medias-count"] = len(permit_medias)
-            reservations = data.get("ActiveReservations")
-            if isinstance(reservations, list):
-                summary["active-reservations-count"] = len(reservations)
-            return summary
-        if isinstance(data, list):
-            return {"response-type": "list", "items": len(data)}
-        return {"response-type": type(data).__name__}
+        self._plogger.response_status(status)
 
     def _log_response_summary(self, data: Any) -> None:
-        """Log a safe debug summary of a successful JSON response."""
-        self._logger.debug(
-            "Provider %s response summary %s",
-            self.provider_id,
-            self._mask_log_value(self._build_response_summary(data)),
-        )
+        self._plogger.response_summary(data)
 
     def _log_request_failure(
         self,
@@ -368,27 +186,30 @@ class BaseProvider(ABC):
         body: str | None = None,
         content_type: str | None = None,
     ) -> None:
-        """Log an unsuccessful provider HTTP response."""
-        is_auth = status in (401, 403)
-        label = "auth request failed" if is_auth else "request failed"
-        detail = f"{method.upper()} {url}" if method and url else url
-        fields: dict[str, Any] = {"status": status}
-        if operation:
-            fields["operation"] = operation
-        if content_type:
-            fields["content-type"] = content_type
-        fields["response_kind"] = self._response_kind(content_type, body)
-        if payload is not None:
-            fields["payload"] = self._mask_payload(payload)
-        if fields["response_kind"] == "html" and body:
-            fields.update(self._extract_html_log_fields(body))
-        elif body:
-            fields["body"] = self._summarize_log_text(body)
-        self._log_warning_block(label, fields, detail=detail)
+        self._plogger.request_failure(
+            status,
+            method=method,
+            url=url,
+            operation=operation,
+            payload=payload,
+            body=body,
+            content_type=content_type,
+        )
 
     def _log_invalid_json(self, body: str) -> None:
-        """Log an invalid JSON response body."""
-        self._log_warning_block("invalid json response", {"body": self._summarize_log_text(body)})
+        self._plogger.invalid_json(body)
+
+    def _mask_payload(self, payload: Any) -> Any:
+        return self._plogger.mask_payload(payload)
+
+    def _mask_log_value(self, value: Any, *, parent_key: str | None = None) -> Any:
+        return self._plogger.mask_value(value, parent_key=parent_key)
+
+    def _summarize_log_text(self, value: str) -> str:
+        return self._plogger.summarize_text(value)
+
+    def _build_response_summary(self, data: Any) -> dict[str, Any]:
+        return self._plogger.build_response_summary(data)
 
     async def _request_with_optional_reauth(
         self,
@@ -590,28 +411,18 @@ class BaseProvider(ABC):
         last_error: Exception | None = None
         for attempt in range(attempts):
             if attempts > 1:
-                self._logger.debug(
-                    "Provider %s request %s %s (attempt %s/%s)",
-                    self.provider_id,
+                self._plogger.debug(
+                    "request %s %s (attempt %s/%s)",
                     method.upper(),
                     url,
                     attempt + 1,
                     attempts,
                 )
             else:
-                self._logger.debug(
-                    "Provider %s request %s %s",
-                    self.provider_id,
-                    method.upper(),
-                    url,
-                )
+                self._plogger.debug("request %s %s", method.upper(), url)
             payload = request_kwargs.get("json")
             if payload is not None:
-                self._logger.debug(
-                    "Provider %s request payload %s",
-                    self.provider_id,
-                    self._mask_payload(payload),
-                )
+                self._plogger.debug("request payload %s", self._plogger.mask_payload(payload))
             try:
                 timeout = request_kwargs.get("timeout", self._timeout)
                 if timeout is None:
@@ -799,10 +610,7 @@ class BaseProvider(ABC):
     ) -> Favorite:
         """Update a favorite."""
         if not self.favorite_update_possible:
-            self._logger.info(
-                "Provider %s favorite update requested but not supported",
-                self.provider_id,
-            )
+            self._plogger.info("favorite update requested but not supported")
             raise ProviderError("Favorite updates are not supported.")
         if license_plate is not None and "license_plate" not in self.favorite_update_fields:
             raise ValidationError("license_plate updates are not supported.")

--- a/src/pycityvisitorparking/provider/dvsportal/api.py
+++ b/src/pycityvisitorparking/provider/dvsportal/api.py
@@ -58,7 +58,7 @@ class Provider(BaseProvider):
         self._state = PortalSessionState()
         self._profile = profile or DvsPortalProfile()
         self._mapper = PortalMapper(self, self._state)
-        self._transport = PortalTransport(self, self._state, self._profile)
+        self._transport = PortalTransport(self, self._state, self._profile, self._plogger)
         self._operation_lock = asyncio.Lock()
         self._lock_owner: asyncio.Task[Any] | None = None
 
@@ -140,7 +140,9 @@ class Provider(BaseProvider):
                     # Some deployments include Permit/Permits in the login response
                     # before PermitMedias is fully populated. Fall back to getbase
                     # so a successful login does not regress into an auth failure.
-                    self._log_missing_response_data("login", fallback="fetching base")
+                    self._log_missing_response_data(
+                        "login", fallback="fetching base", response_data=permit
+                    )
                     await self._fetch_base(operation="login", allow_reauth=False)
             else:
                 await self._fetch_base(operation="login", allow_reauth=False)
@@ -397,10 +399,14 @@ class Provider(BaseProvider):
                 json=payload,
                 operation="add_favorite",
             )
+            if data.get("ErrorMessage"):
+                self._log_provider_error_response(data, operation="favorite upsert")
             try:
                 favorites = self._mapper.favorites_from_permit(self._mapper.extract_permit(data))
             except ProviderError:
-                self._log_missing_response_data("favorite upsert", fallback="refetching list")
+                self._log_missing_response_data(
+                    "favorite upsert", fallback="refetching list", response_data=data
+                )
                 favorites = self._mapper.favorites_from_permit(
                     await self._fetch_base(operation="add_favorite")
                 )
@@ -473,10 +479,12 @@ class Provider(BaseProvider):
         operation: str = "fetch_base",
     ) -> dict[str, Any]:
         """Extract permit from a response, falling back to a full fetch on failure."""
+        if data.get("ErrorMessage"):
+            self._log_provider_error_response(data, operation=label)
         try:
             permit = self._mapper.extract_permit(data)
         except ProviderError:
-            self._log_missing_response_data(label)
+            self._log_missing_response_data(label, response_data=data)
             return await self._fetch_base(operation=operation)
         self._mapper.cache_defaults(permit)
         return permit

--- a/src/pycityvisitorparking/provider/dvsportal/api.py
+++ b/src/pycityvisitorparking/provider/dvsportal/api.py
@@ -69,7 +69,7 @@ class Provider(BaseProvider):
     ) -> None:
         """Authenticate against the provider."""
         async with self._operation_guard():
-            self._log_operation_started("login")
+            self._plogger.operation_started("login")
             await self._transport.fetch_app_env()
             merged = self._merge_credentials(credentials, **kwargs)
             username = merged.get("username")
@@ -104,13 +104,10 @@ class Provider(BaseProvider):
             error_message = data.get("ErrorMessage")
             requires_otp = data.get("RequiresOtp")
             if self._profile.is_login_error(data, status_value):
-                self._log_with_metadata(
+                self._plogger.log(
                     logging.WARNING,
-                    (
-                        "Provider %s login failed: LoginStatus=%r token_present=%s "
-                        "requires_otp=%r error_message=%r"
-                    ),
-                    self.provider_id,
+                    "login failed: LoginStatus=%r token_present=%s "
+                    "requires_otp=%r error_message=%r",
                     status_value,
                     bool(token),
                     requires_otp,
@@ -140,14 +137,14 @@ class Provider(BaseProvider):
                     # Some deployments include Permit/Permits in the login response
                     # before PermitMedias is fully populated. Fall back to getbase
                     # so a successful login does not regress into an auth failure.
-                    self._log_missing_response_data(
+                    self._plogger.missing_response_data(
                         "login", fallback="fetching base", response_data=permit
                     )
                     await self._fetch_base(operation="login", allow_reauth=False)
             else:
                 await self._fetch_base(operation="login", allow_reauth=False)
 
-            self._log_operation_completed(
+            self._plogger.operation_completed(
                 "login",
                 login_status=status_value,
                 token_present=bool(token),
@@ -157,20 +154,20 @@ class Provider(BaseProvider):
     async def get_permit(self) -> Permit:
         """Return the active permit for the account."""
         async with self._operation_guard():
-            self._log_operation_started("get_permit")
+            self._plogger.operation_started("get_permit")
             permit = await self._fetch_base(operation="get_permit")
             mapped = self._mapper.map_permit(permit)
-            self._log_operation_completed("get_permit")
+            self._plogger.operation_completed("get_permit")
             return mapped
 
     async def list_reservations(self) -> list[Reservation]:
         """Return active reservations."""
         async with self._operation_guard():
-            self._log_operation_started("list_reservations")
+            self._plogger.operation_started("list_reservations")
             reservations = self._mapper.reservations_from_permit(
                 await self._fetch_base(operation="list_reservations")
             )
-            self._log_operation_completed("list_reservations", count=len(reservations))
+            self._plogger.operation_completed("list_reservations", count=len(reservations))
             return reservations
 
     async def start_reservation(
@@ -182,7 +179,7 @@ class Provider(BaseProvider):
     ) -> Reservation:
         """Start a reservation for a license plate."""
         async with self._operation_guard():
-            self._log_operation_started("start_reservation")
+            self._plogger.operation_started("start_reservation")
             start_time_utc, end_time_utc = self._validate_reservation_times(
                 start_time,
                 end_time,
@@ -223,7 +220,7 @@ class Provider(BaseProvider):
             )
             if reservation is None:
                 raise ProviderError("Reservation was not returned by the provider.")
-            self._log_operation_completed("start_reservation")
+            self._plogger.operation_completed("start_reservation")
             return reservation
 
     async def update_reservation(
@@ -235,7 +232,7 @@ class Provider(BaseProvider):
     ) -> Reservation:
         """Update a reservation."""
         async with self._operation_guard():
-            self._log_operation_started("update_reservation")
+            self._plogger.operation_started("update_reservation")
             if not self.reservation_update_possible:
                 raise ProviderError("Reservation updates are not supported.")
             if start_time is not None or name is not None:
@@ -254,7 +251,7 @@ class Provider(BaseProvider):
                 reservation_id=reservation_id_value,
             )
             if existing is None:
-                self._log_operation_failed("update_reservation", "reservation_id not found")
+                self._plogger.operation_failed("update_reservation", "reservation_id not found")
                 raise ValidationError("reservation_id was not found.")
             if self._state.permit_media_type_id is None or self._state.permit_media_code is None:
                 raise ProviderError("Permit media defaults are missing.")
@@ -292,7 +289,7 @@ class Provider(BaseProvider):
             )
             if updated is None:
                 raise ProviderError("Reservation was not returned by the provider.")
-            self._log_operation_completed("update_reservation")
+            self._plogger.operation_completed("update_reservation")
             return updated
 
     async def end_reservation(
@@ -302,7 +299,7 @@ class Provider(BaseProvider):
     ) -> Reservation:
         """End a reservation."""
         async with self._operation_guard():
-            self._log_operation_started("end_reservation")
+            self._plogger.operation_started("end_reservation")
             end_dt = self._normalize_datetime(end_time)
             normalized_end_time = self._format_utc_timestamp(end_dt)
             await self._ensure_defaults(operation="end_reservation")
@@ -313,7 +310,7 @@ class Provider(BaseProvider):
                 reservation_id=reservation_id,
             )
             if existing is None:
-                self._log_operation_failed("end_reservation", "reservation_id not found")
+                self._plogger.operation_failed("end_reservation", "reservation_id not found")
                 raise ValidationError("reservation_id was not found.")
             payload = {
                 "permitMediaTypeID": self._state.permit_media_type_id,
@@ -339,28 +336,28 @@ class Provider(BaseProvider):
                 start_time=existing.start_time,
                 end_time=normalized_end_time,
             )
-            self._log_operation_completed("end_reservation")
+            self._plogger.operation_completed("end_reservation")
             return reservation
 
     async def list_favorites(self) -> list[Favorite]:
         """Return stored favorites."""
         async with self._operation_guard():
-            self._log_operation_started("list_favorites")
+            self._plogger.operation_started("list_favorites")
             favorites = self._mapper.favorites_from_permit(
                 await self._fetch_base(operation="list_favorites")
             )
-            self._log_operation_completed("list_favorites", count=len(favorites))
+            self._plogger.operation_completed("list_favorites", count=len(favorites))
             return favorites
 
     async def fetch_all(self) -> tuple[Permit, list[Reservation], list[Favorite]]:
         """Return permit, reservations, and favorites with a single provider fetch."""
         async with self._operation_guard():
-            self._log_operation_started("fetch_all")
+            self._plogger.operation_started("fetch_all")
             permit_raw = await self._fetch_base(operation="fetch_all")
             permit = self._mapper.map_permit(permit_raw)
             reservations = self._mapper.reservations_from_permit(permit_raw)
             favorites = self._mapper.favorites_from_permit(permit_raw)
-            self._log_operation_completed(
+            self._plogger.operation_completed(
                 "fetch_all",
                 reservations=len(reservations),
                 favorites=len(favorites),
@@ -370,14 +367,14 @@ class Provider(BaseProvider):
     async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
         """Add a favorite."""
         async with self._operation_guard():
-            self._log_operation_started("add_favorite")
+            self._plogger.operation_started("add_favorite")
             normalized_plate = self._normalize_license_plate(license_plate)
             favorites = self._mapper.favorites_from_permit(
                 await self._fetch_base(operation="add_favorite")
             )
             for favorite in favorites:
                 if favorite.license_plate == normalized_plate:
-                    self._log_operation_failed("add_favorite", "duplicate license_plate")
+                    self._plogger.operation_failed("add_favorite", "duplicate license_plate")
                     raise ValidationError("license_plate is already a favorite.")
             if self._state.permit_media_type_id is None or self._state.permit_media_code is None:
                 raise ProviderError("Permit media defaults are missing.")
@@ -400,11 +397,11 @@ class Provider(BaseProvider):
                 operation="add_favorite",
             )
             if data.get("ErrorMessage"):
-                self._log_provider_error_response(data, operation="favorite upsert")
+                self._plogger.provider_error_response(data, operation="favorite upsert")
             try:
                 favorites = self._mapper.favorites_from_permit(self._mapper.extract_permit(data))
             except ProviderError:
-                self._log_missing_response_data(
+                self._plogger.missing_response_data(
                     "favorite upsert", fallback="refetching list", response_data=data
                 )
                 favorites = self._mapper.favorites_from_permit(
@@ -413,7 +410,7 @@ class Provider(BaseProvider):
             favorite = self._mapper.select_favorite(favorites, normalized_plate)
             if favorite is None:
                 raise ProviderError("Favorite was not returned by the provider.")
-            self._log_operation_completed("add_favorite")
+            self._plogger.operation_completed("add_favorite")
             return favorite
 
     async def _update_favorite_native(
@@ -428,7 +425,7 @@ class Provider(BaseProvider):
     async def remove_favorite(self, favorite_id: str) -> None:
         """Remove a favorite."""
         async with self._operation_guard():
-            self._log_operation_started("remove_favorite")
+            self._plogger.operation_started("remove_favorite")
             normalized_plate = self._normalize_license_plate(favorite_id)
             favorites = self._mapper.favorites_from_permit(
                 await self._fetch_base(operation="remove_favorite")
@@ -452,7 +449,7 @@ class Provider(BaseProvider):
                 json=payload,
                 operation="remove_favorite",
             )
-            self._log_operation_completed("remove_favorite")
+            self._plogger.operation_completed("remove_favorite")
 
     async def _fetch_permit_media_type_id(self, *, operation: str = "login") -> str | int:
         """Return the default permit media type ID from the login bootstrap call."""
@@ -480,11 +477,11 @@ class Provider(BaseProvider):
     ) -> dict[str, Any]:
         """Extract permit from a response, falling back to a full fetch on failure."""
         if data.get("ErrorMessage"):
-            self._log_provider_error_response(data, operation=label)
+            self._plogger.provider_error_response(data, operation=label)
         try:
             permit = self._mapper.extract_permit(data)
         except ProviderError:
-            self._log_missing_response_data(label, response_data=data)
+            self._plogger.missing_response_data(label, response_data=data)
             return await self._fetch_base(operation=operation)
         self._mapper.cache_defaults(permit)
         return permit

--- a/src/pycityvisitorparking/provider/dvsportal/transport.py
+++ b/src/pycityvisitorparking/provider/dvsportal/transport.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 
 from ...exceptions import AuthError, ProviderError
-from ..logger import get_provider_logger
+from ..logger import ProviderLogger
 from .const import APP_ENV_SCRIPT, AUTH_HEADER, DEFAULT_HEADERS, RETRY_AFTER_HEADER, XSRF_HEADER
 
 _XSRF_COOKIE_NAME_RE = re.compile(r"window\.__env\.xsrfCookieName\s*=\s*['\"]([^'\"]+)['\"]")
@@ -17,9 +17,6 @@ _XSRF_COOKIE_NAME_RE = re.compile(r"window\.__env\.xsrfCookieName\s*=\s*['\"]([^
 if TYPE_CHECKING:
     from .profile import PortalProfile
     from .session import PortalSessionState
-
-
-_LOGGER = get_provider_logger(__name__)
 
 
 class PortalTransport:
@@ -30,11 +27,13 @@ class PortalTransport:
         provider: Any,
         state: PortalSessionState,
         profile: PortalProfile,
+        plogger: ProviderLogger,
     ) -> None:
         """Initialize transport helpers with shared provider state."""
         self._provider = provider
         self._state = state
         self._profile = profile
+        self._plogger = plogger
 
     async def fetch_app_env(self) -> None:
         """Bootstrap the XSRF cookie before login.
@@ -78,30 +77,26 @@ class PortalTransport:
                     if match:
                         cookie_name = match.group(1)
                         self._profile.update_xsrf_cookie_name(cookie_name)
-                        _LOGGER.debug(
-                            "Provider %s discovered xsrfCookieName=%r from %s",
-                            self._provider.provider_id,
+                        self._plogger.debug(
+                            "discovered xsrfCookieName=%r from %s",
                             cookie_name,
                             env_url,
                         )
                         step1_ok = True
                     else:
-                        _LOGGER.debug(
-                            "Provider %s app.env.js missing xsrfCookieName url=%s",
-                            self._provider.provider_id,
+                        self._plogger.debug(
+                            "app.env.js missing xsrfCookieName url=%s",
                             env_url,
                         )
                 else:
-                    _LOGGER.debug(
-                        "Provider %s app.env.js bootstrap status=%s url=%s",
-                        self._provider.provider_id,
+                    self._plogger.debug(
+                        "app.env.js bootstrap status=%s url=%s",
                         response.status,
                         env_url,
                     )
         except Exception as exc:
-            _LOGGER.debug(
-                "Provider %s app.env.js bootstrap failed url=%s error=%s",
-                self._provider.provider_id,
+            self._plogger.debug(
+                "app.env.js bootstrap failed url=%s error=%s",
                 env_url,
                 exc.__class__.__name__,
             )
@@ -114,9 +109,8 @@ class PortalTransport:
             async with self._provider._session.request(
                 "GET", html_url, timeout=timeout
             ) as response:
-                _LOGGER.debug(
-                    "Provider %s fetched app HTML status=%s url=%s",
-                    self._provider.provider_id,
+                self._plogger.debug(
+                    "fetched app HTML status=%s url=%s",
                     response.status,
                     html_url,
                 )
@@ -124,9 +118,8 @@ class PortalTransport:
                 if response.status == 200:
                     step2_ok = True
         except Exception as exc:
-            _LOGGER.debug(
-                "Provider %s app HTML bootstrap failed url=%s error=%s",
-                self._provider.provider_id,
+            self._plogger.debug(
+                "app HTML bootstrap failed url=%s error=%s",
                 html_url,
                 exc.__class__.__name__,
             )
@@ -232,7 +225,7 @@ class PortalTransport:
             if not 200 <= response.status < 300:
                 body = await response.text()
                 content_type = response.headers.get("Content-Type")
-                self._provider._log_request_failure(
+                self._plogger.request_failure(
                     response.status,
                     method=method,
                     url=url,
@@ -244,14 +237,14 @@ class PortalTransport:
                 if response.status in (401, 403):
                     raise AuthError("Authentication failed.")
                 raise ProviderError(f"Provider request failed with status {response.status}.")
-            self._provider._log_response_status(response.status)
+            self._plogger.response_status(response.status)
             if expect_json:
                 try:
                     data = await response.json()
                 except (aiohttp.ContentTypeError, ValueError) as exc:
-                    self._provider._log_invalid_json(await response.text())
+                    self._plogger.invalid_json(await response.text())
                     raise ProviderError("Response did not contain valid JSON.") from exc
-                self._provider._log_response_summary(data)
+                self._plogger.response_summary(data)
                 return data
             return await response.text()
 
@@ -281,7 +274,7 @@ class PortalTransport:
 
     async def _reauthenticate(self) -> None:
         """Clear auth state and re-login using cached credentials."""
-        self._provider._log_warning_block(
+        self._plogger.warning_block(
             "reauthenticating",
             {
                 "token-present": self._state.token is not None,
@@ -320,12 +313,11 @@ class PortalTransport:
         include_auth: bool,
     ) -> None:
         """Log safe request-context flags for troubleshooting auth/session issues."""
-        _LOGGER.debug(
-            "Provider %s request context method=%s url=%s include_auth=%s "
+        self._plogger.debug(
+            "request context method=%s url=%s include_auth=%s "
             "auth_header_present=%s xsrf_header_present=%s "
             "session_authenticated=%s token_present=%s "
             "permit_media_code=%s",
-            self._provider.provider_id,
             method.upper(),
             url,
             include_auth,
@@ -333,7 +325,7 @@ class PortalTransport:
             XSRF_HEADER in headers,
             self._state.session_authenticated,
             self._state.token is not None,
-            self._provider._mask_log_value(
+            self._plogger.mask_value(
                 self._state.permit_media_code,
                 parent_key="permit_media_code",
             ),

--- a/src/pycityvisitorparking/provider/logger.py
+++ b/src/pycityvisitorparking/provider/logger.py
@@ -3,8 +3,38 @@
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Callable
+from typing import Any
 
 _PROVIDER_LOGGER_NAME = "pycityvisitorparking.provider"
+
+_MAX_LOG_BODY_CHARS = 600
+_HTML_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_HTML_BASE_RE = re.compile(
+    r"""<base[^>]+href\s*=\s*["']?([^"'\s>]+)""",
+    re.IGNORECASE | re.DOTALL,
+)
+_SENSITIVE_KEYS = frozenset(
+    {
+        "Authorization",
+        "Token",
+        "asIdentifier",
+        "identifier",
+        "otp",
+        "password",
+        "permitId",
+        "permitMediaCode",
+        "permit_id",
+        "permit_media_code",
+        "resetCode",
+        "token",
+        "username",
+        "zipCode",
+    }
+)
+_SENSITIVE_OBJECT_KEYS = frozenset({"LicensePlate", "licensePlate", "updateLicensePlate"})
+_SENSITIVE_NESTED_KEYS = frozenset({"DisplayValue", "Name", "Value"})
 
 
 def get_provider_logger(module_name: str | None = None) -> logging.Logger:
@@ -16,3 +46,314 @@ def get_provider_logger(module_name: str | None = None) -> logging.Logger:
     if module_name.startswith(f"{_PROVIDER_LOGGER_NAME}."):
         return logging.getLogger(module_name)
     return logging.getLogger(f"{_PROVIDER_LOGGER_NAME}.{module_name}")
+
+
+class ProviderLogger:
+    """Structured logging helper bound to a specific provider instance.
+
+    Encapsulates all formatted log output for provider operations so that
+    ``BaseProvider`` and transport helpers stay focused on HTTP/API logic.
+    Metadata (provider id, city, version strings) is fetched lazily on each
+    call via *get_metadata*, which allows the context to evolve after
+    construction (e.g. when ``set_request_context`` or
+    ``set_runtime_versions`` is called on the provider).
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        get_metadata: Callable[[], tuple[str, str, str, str]],
+    ) -> None:
+        """Initialise with a logger and a metadata callback.
+
+        Args:
+            logger: The :class:`logging.Logger` to emit records on.
+            get_metadata: Callable that returns
+                ``(provider_id, city, ha_cvp_version, pycvp_version)``.
+        """
+        self._logger = logger
+        self._get_metadata = get_metadata
+
+    # ------------------------------------------------------------------
+    # Masking
+    # ------------------------------------------------------------------
+
+    def mask_value(self, value: Any, *, parent_key: str | None = None) -> Any:
+        """Return a copy of *value* with sensitive fields replaced by ``'***'``."""
+        if parent_key in _SENSITIVE_KEYS:
+            return "***" if value is not None else None
+        if isinstance(value, dict):
+            return {
+                key: ("***" if key in _SENSITIVE_KEYS else self.mask_value(item, parent_key=key))
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self.mask_value(item, parent_key=parent_key) for item in value]
+        if parent_key in _SENSITIVE_OBJECT_KEYS:
+            return "***" if value is not None else None
+        if parent_key in _SENSITIVE_NESTED_KEYS:
+            return "***" if value is not None else None
+        return value
+
+    def mask_payload(self, payload: Any) -> Any:
+        """Return a masked copy of a request payload."""
+        return self.mask_value(payload)
+
+    # ------------------------------------------------------------------
+    # Text helpers
+    # ------------------------------------------------------------------
+
+    def summarize_text(self, value: str) -> str:
+        """Compact whitespace and truncate *value* for safe log output."""
+        compact = " ".join(value.split())
+        if len(compact) > _MAX_LOG_BODY_CHARS:
+            return compact[: _MAX_LOG_BODY_CHARS - 3] + "..."
+        return compact
+
+    def build_response_summary(self, data: Any) -> dict[str, Any]:
+        """Return a safe summary of provider response structure and metadata."""
+        if isinstance(data, dict):
+            summary: dict[str, Any] = {
+                "response-type": "dict",
+                "response-keys": self._response_keys_summary(data),
+            }
+            if "Result" in data:
+                summary["result"] = data.get("Result")
+            if "LoginStatus" in data:
+                summary["login-status"] = data.get("LoginStatus")
+            if "RequiresOtp" in data:
+                summary["requires-otp"] = data.get("RequiresOtp")
+            if "Redirect" in data:
+                summary["redirect"] = data.get("Redirect")
+            if "ErrorMessage" in data and data.get("ErrorMessage"):
+                summary["error-message"] = self.summarize_text(str(data["ErrorMessage"]))
+            if "Token" in data:
+                summary["token-present"] = bool(data.get("Token"))
+            if "Permit" in data:
+                summary["has-permit"] = isinstance(data.get("Permit"), dict)
+            permits = data.get("Permits")
+            if isinstance(permits, list):
+                summary["permits-count"] = len(permits)
+            permit_medias = data.get("PermitMedias")
+            if isinstance(permit_medias, list):
+                summary["permit-medias-count"] = len(permit_medias)
+            reservations = data.get("ActiveReservations")
+            if isinstance(reservations, list):
+                summary["active-reservations-count"] = len(reservations)
+            return summary
+        if isinstance(data, list):
+            return {"response-type": "list", "items": len(data)}
+        return {"response-type": type(data).__name__}
+
+    # ------------------------------------------------------------------
+    # Core log emitters
+    # ------------------------------------------------------------------
+
+    def debug(self, message: str, *args: Any) -> None:
+        """Emit a DEBUG line prefixed with ``Provider {id}``."""
+        provider_id = self._get_metadata()[0]
+        self._logger.debug("Provider %s " + message, provider_id, *args)
+
+    def info(self, message: str, *args: Any) -> None:
+        """Emit an INFO line prefixed with ``Provider {id}``."""
+        provider_id = self._get_metadata()[0]
+        self._logger.info("Provider %s " + message, provider_id, *args)
+
+    def log(self, level: int, message: str, *args: Any) -> None:
+        """Emit a log line at *level* appending full provider metadata."""
+        provider, city, ha_cvp, pycvp = self._get_metadata()
+        self._logger.log(
+            level,
+            f"{message} (provider=%s, city=%s, hacvp=%s, pycvp=%s)",
+            *args,
+            provider,
+            city,
+            ha_cvp,
+            pycvp,
+        )
+
+    def warning_block(
+        self,
+        label: str,
+        fields: dict[str, Any],
+        *,
+        detail: str | None = None,
+    ) -> None:
+        """Emit a WARNING as a labelled multi-line key=value block with metadata."""
+        provider, city, ha_cvp, pycvp = self._get_metadata()
+        all_fields = {k: v for k, v in fields.items() if v is not None}
+        all_fields.update({"provider": provider, "city": city, "hacvp": ha_cvp, "pycvp": pycvp})
+        width = max(len(k) for k in all_fields)
+        lines = [label]
+        if detail:
+            lines.append(f"  {detail}")
+        for key, value in all_fields.items():
+            lines.append(f"  {key:<{width}} = {value}")
+        self._logger.warning("%s", "\n".join(lines))
+
+    # ------------------------------------------------------------------
+    # Operation lifecycle
+    # ------------------------------------------------------------------
+
+    def operation_started(self, operation: str, **details: Any) -> None:
+        """Log the start of a provider operation."""
+        self.debug("%s started%s", operation, self._format_details(**details))
+
+    def operation_completed(self, operation: str, **details: Any) -> None:
+        """Log successful completion of a provider operation."""
+        self.debug("%s completed%s", operation, self._format_details(**details))
+
+    def operation_failed(self, operation: str, reason: str, **details: Any) -> None:
+        """Log a provider operation failure before raising an error."""
+        self.debug("%s failed: %s%s", operation, reason, self._format_details(**details))
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def reauth_triggered(self) -> None:
+        """Log when a request falls back to reauthentication."""
+        self.warning_block("reauth triggered", {})
+
+    def reauthenticating(self) -> None:
+        """Log when cached credentials are used to reauthenticate."""
+        self.debug("reauthenticating with cached credentials")
+
+    # ------------------------------------------------------------------
+    # HTTP response / request
+    # ------------------------------------------------------------------
+
+    def response_status(self, status: int) -> None:
+        """Log the HTTP response status."""
+        self.debug("response status=%s", status)
+
+    def response_summary(self, data: Any) -> None:
+        """Log a safe debug summary of a successful JSON response."""
+        self.debug("response summary %s", self.mask_value(self.build_response_summary(data)))
+
+    def request_failure(
+        self,
+        status: int,
+        *,
+        method: str | None = None,
+        url: str | None = None,
+        operation: str | None = None,
+        payload: Any = None,
+        body: str | None = None,
+        content_type: str | None = None,
+    ) -> None:
+        """Log an unsuccessful provider HTTP response."""
+        is_auth = status in (401, 403)
+        label = "auth request failed" if is_auth else "request failed"
+        detail = f"{method.upper()} {url}" if method and url else url
+        fields: dict[str, Any] = {"status": status}
+        if operation:
+            fields["operation"] = operation
+        if content_type:
+            fields["content-type"] = content_type
+        fields["response_kind"] = self._response_kind(content_type, body)
+        if payload is not None:
+            fields["payload"] = self.mask_payload(payload)
+        if fields["response_kind"] == "html" and body:
+            fields.update(self._extract_html_log_fields(body))
+        elif body:
+            fields["body"] = self.summarize_text(body)
+        self.warning_block(label, fields, detail=detail)
+
+    def invalid_json(self, body: str) -> None:
+        """Log an invalid JSON response body."""
+        self.warning_block("invalid json response", {"body": self.summarize_text(body)})
+
+    # ------------------------------------------------------------------
+    # Domain events
+    # ------------------------------------------------------------------
+
+    def missing_response_data(
+        self,
+        label: str,
+        fallback: str = "refetching",
+        *,
+        response_data: Any = None,
+    ) -> None:
+        """Log when a response is missing expected data and a fallback is used."""
+        fields: dict[str, Any] = {"operation": label, "fallback": fallback}
+        if isinstance(response_data, dict):
+            summary = self.build_response_summary(response_data)
+            if "response-keys" in summary:
+                fields["response-keys"] = summary["response-keys"]
+            if "error-message" in summary:
+                fields["error-message"] = summary["error-message"]
+            message = response_data.get("Message")
+            if message and "error-message" not in fields:
+                fields["error-message"] = self.summarize_text(str(message))
+        self.warning_block("missing permit in response", fields)
+
+    def provider_error_response(
+        self,
+        data: dict[str, Any],
+        *,
+        operation: str | None = None,
+    ) -> None:
+        """Log when a provider returns HTTP 200 with an ErrorMessage in the body.
+
+        DVS Portal signals application-level failures via ``ErrorMessage`` +
+        ``Result`` fields in an otherwise successful (2xx) response.  Logging
+        this as its own warning makes the root cause immediately visible,
+        before any subsequent ``missing_response_data`` fallback message.
+        """
+        fields: dict[str, Any] = {}
+        if operation:
+            fields["operation"] = operation
+        result = data.get("Result")
+        if result is not None:
+            fields["result"] = result
+        error_message = data.get("ErrorMessage") or data.get("Message")
+        if error_message:
+            fields["error-message"] = self.summarize_text(str(error_message))
+        self.warning_block("provider error in response", fields)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _response_kind(self, content_type: str | None, body: str | None) -> str:
+        """Classify a failed response body for compact diagnostics."""
+        if not body:
+            return "empty"
+        lowered_type = (content_type or "").lower()
+        if "html" in lowered_type:
+            return "html"
+        compact = body.lstrip().lower()
+        if compact.startswith("<!doctype html") or compact.startswith("<html"):
+            return "html"
+        return "text"
+
+    def _extract_html_log_fields(self, body: str) -> dict[str, str]:
+        """Return compact HTML diagnostics without logging the full page body."""
+        fields: dict[str, str] = {}
+        title_match = _HTML_TITLE_RE.search(body)
+        if title_match:
+            title = self.summarize_text(title_match.group(1))
+            if title:
+                fields["html_title"] = title
+        base_match = _HTML_BASE_RE.search(body)
+        if base_match:
+            base_href = self.summarize_text(base_match.group(1))
+            if base_href:
+                fields["html_base_href"] = base_href
+        if not fields:
+            fields["body_excerpt"] = self.summarize_text(body)
+        return fields
+
+    def _response_keys_summary(self, data: dict[str, Any]) -> str:
+        """Return a compact summary of top-level response keys."""
+        keys = sorted(str(key) for key in data)
+        if len(keys) > 12:
+            return ", ".join(keys[:12]) + ", ..."
+        return ", ".join(keys)
+
+    def _format_details(self, **details: Any) -> str:
+        """Serialize optional details as a compact key=value suffix."""
+        if not details:
+            return ""
+        return " " + " ".join(f"{key}={value}" for key, value in details.items())

--- a/src/pycityvisitorparking/provider/the_hague/api.py
+++ b/src/pycityvisitorparking/provider/the_hague/api.py
@@ -80,7 +80,7 @@ class Provider(BaseProvider):
         **kwargs: object,
     ) -> None:
         """Authenticate against the provider."""
-        self._log_operation_started("login")
+        self._plogger.operation_started("login")
         merged = self._merge_credentials(credentials, **kwargs)
         username = merged.get("username")
         password = merged.get("password")
@@ -108,22 +108,22 @@ class Provider(BaseProvider):
             self._credentials["permit_media_type_id"] = permit_media_type_id
         self._permit_media_type_id = permit_media_type_id
         self._logged_in = True
-        self._log_operation_completed("login")
+        self._plogger.operation_completed("login")
 
     async def get_permit(self) -> Permit:
         """Return the active permit for the account."""
-        self._log_operation_started("get_permit")
+        self._plogger.operation_started("get_permit")
         account = await self._request_json("GET", ACCOUNT_ENDPOINT, allow_reauth=True)
         permit = self._map_permit(account)
-        self._log_operation_completed("get_permit")
+        self._plogger.operation_completed("get_permit")
         return permit
 
     async def list_reservations(self) -> list[Reservation]:
         """Return active reservations."""
-        self._log_operation_started("list_reservations")
+        self._plogger.operation_started("list_reservations")
         data = await self._request_json("GET", RESERVATION_ENDPOINT, allow_reauth=True)
         reservations = self._map_reservation_list(data)
-        self._log_operation_completed("list_reservations", count=len(reservations))
+        self._plogger.operation_completed("list_reservations", count=len(reservations))
         return reservations
 
     async def start_reservation(
@@ -134,7 +134,7 @@ class Provider(BaseProvider):
         name: str | None = None,
     ) -> Reservation:
         """Start a reservation for a license plate."""
-        self._log_operation_started("start_reservation")
+        self._plogger.operation_started("start_reservation")
         start_dt, end_dt = self._validate_reservation_times(
             start_time,
             end_time,
@@ -159,7 +159,7 @@ class Provider(BaseProvider):
             allow_reauth=True,
         )
         reservation = self._map_reservation(data)
-        self._log_operation_completed("start_reservation")
+        self._plogger.operation_completed("start_reservation")
         return reservation
 
     async def update_reservation(
@@ -170,7 +170,7 @@ class Provider(BaseProvider):
         name: str | None = None,
     ) -> Reservation:
         """Update a reservation."""
-        self._log_operation_started("update_reservation")
+        self._plogger.operation_started("update_reservation")
         if not self.reservation_update_possible:
             raise ProviderError("Reservation updates are not supported.")
         if start_time is not None or name is not None:
@@ -188,7 +188,7 @@ class Provider(BaseProvider):
             allow_reauth=True,
         )
         reservation = self._map_reservation(data)
-        self._log_operation_completed("update_reservation")
+        self._plogger.operation_completed("update_reservation")
         return reservation
 
     async def end_reservation(
@@ -197,7 +197,7 @@ class Provider(BaseProvider):
         end_time: datetime,
     ) -> Reservation:
         """End a reservation."""
-        self._log_operation_started("end_reservation")
+        self._plogger.operation_started("end_reservation")
         reservation_id_value = self._require_id(reservation_id, "reservation_id")
         end_dt = self._normalize_datetime(end_time)
         normalized_end_time = self._format_utc_timestamp(end_dt)
@@ -216,20 +216,20 @@ class Provider(BaseProvider):
             start_time=existing.start_time,
             end_time=normalized_end_time,
         )
-        self._log_operation_completed("end_reservation")
+        self._plogger.operation_completed("end_reservation")
         return reservation
 
     async def list_favorites(self) -> list[Favorite]:
         """Return stored favorites."""
-        self._log_operation_started("list_favorites")
+        self._plogger.operation_started("list_favorites")
         data = await self._request_json("GET", FAVORITE_ENDPOINT, allow_reauth=True)
         favorites = self._map_favorite_list(data)
-        self._log_operation_completed("list_favorites", count=len(favorites))
+        self._plogger.operation_completed("list_favorites", count=len(favorites))
         return favorites
 
     async def add_favorite(self, license_plate: str, name: str | None = None) -> Favorite:
         """Add a favorite."""
-        self._log_operation_started("add_favorite")
+        self._plogger.operation_started("add_favorite")
         normalized_plate = self._normalize_license_plate(license_plate)
         favorites = await self.list_favorites()
         for favorite in favorites:
@@ -244,7 +244,7 @@ class Provider(BaseProvider):
             allow_reauth=True,
         )
         favorite = self._map_favorite(data)
-        self._log_operation_completed("add_favorite")
+        self._plogger.operation_completed("add_favorite")
         return favorite
 
     async def _update_favorite_native(
@@ -254,7 +254,7 @@ class Provider(BaseProvider):
         name: str | None = None,
     ) -> Favorite:
         """Native favorite update implementation."""
-        self._log_operation_started("update_favorite")
+        self._plogger.operation_started("update_favorite")
         favorite_id_value = self._require_id(favorite_id, "favorite_id")
         if license_plate is None and name is None:
             raise ValidationError("license_plate or name is required.")
@@ -276,19 +276,19 @@ class Provider(BaseProvider):
             allow_reauth=True,
         )
         favorite = self._map_favorite(data)
-        self._log_operation_completed("update_favorite")
+        self._plogger.operation_completed("update_favorite")
         return favorite
 
     async def remove_favorite(self, favorite_id: str) -> None:
         """Remove a favorite."""
-        self._log_operation_started("remove_favorite")
+        self._plogger.operation_started("remove_favorite")
         favorite_id_value = self._require_id(favorite_id, "favorite_id")
         await self._request_text(
             "DELETE",
             f"{FAVORITE_ENDPOINT}/{favorite_id_value}",
             allow_reauth=True,
         )
-        self._log_operation_completed("remove_favorite")
+        self._plogger.operation_completed("remove_favorite")
 
     def _map_permit(self, account: Any) -> Permit:
         if not isinstance(account, dict):
@@ -509,13 +509,13 @@ class Provider(BaseProvider):
                 message = await self._error_message_from_response(response)
                 if message:
                     raise ProviderError(message)
-            self._log_response_status(response.status)
+            self._plogger.response_status(response.status)
             self._raise_for_status(response)
             if expect_json:
                 try:
                     return await response.json()
                 except (aiohttp.ContentTypeError, ValueError) as exc:
-                    self._log_invalid_json(await response.text())
+                    self._plogger.invalid_json(await response.text())
                     raise ProviderError("Response did not contain valid JSON.") from exc
             return await response.text()
 
@@ -537,7 +537,7 @@ class Provider(BaseProvider):
         self._logged_in = False
         if not self._credentials:
             raise AuthError("Authentication required.")
-        self._log_reauthenticating()
+        self._plogger.reauthenticating()
         await self.login(self._credentials)
 
     def _normalize_permit_media_type_id(self, value: Any) -> str | None:

--- a/tests/test_base_provider.py
+++ b/tests/test_base_provider.py
@@ -178,7 +178,7 @@ def test_filter_chargeable_zone_validity_invalid() -> None:
 def test_mask_payload_redacts_login_and_license_plate_data() -> None:
     provider = _DummyProvider(_SequenceSession([]), _manifest(), base_url="https://example.com")
 
-    masked = provider._mask_payload(
+    masked = provider._plogger.mask_payload(
         {
             "identifier": "123456",
             "password": "secret",


### PR DESCRIPTION
## Summary
- add a dedicated `ProviderLogger` class in `logger.py`
- wire `BaseProvider` and `PortalTransport` to use the new logger abstraction
- remove delegate wrappers and update providers to call `self._plogger` directly

## Testing
- not run (branch/PR only)