### PR TITLE
feat: add resolved_login_params to skip redundant API calls on restart

### DIFF
--- a/src/pycityvisitorparking/__init__.py
+++ b/src/pycityvisitorparking/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from .client import Client
+from .const import RESOLVED_LOCATION, RESOLVED_PERMIT_MEDIA_TYPE_ID
 from .exceptions import (
     AuthError,
     ConfigError,
@@ -36,6 +37,8 @@ __all__ = [
     "BALANCE_UNIT_EURO",
     "BALANCE_UNIT_MINUTE",
     "BALANCE_UNIT_TIMES",
+    "RESOLVED_LOCATION",
+    "RESOLVED_PERMIT_MEDIA_TYPE_ID",
     "AuthError",
     "Client",
     "ConfigError",

--- a/src/pycityvisitorparking/const.py
+++ b/src/pycityvisitorparking/const.py
@@ -7,4 +7,5 @@ from typing import Final
 # Keys used in resolved_login_params — match the login() kwargs of the same name
 # so callers can pass them back directly on subsequent starts.
 RESOLVED_LOCATION: Final = "location"
+RESOLVED_PERMIT_ID: Final = "permit_id"
 RESOLVED_PERMIT_MEDIA_TYPE_ID: Final = "permit_media_type_id"

--- a/src/pycityvisitorparking/const.py
+++ b/src/pycityvisitorparking/const.py
@@ -1,0 +1,10 @@
+"""Package-level constants for pyCityVisitorParking."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Keys used in resolved_login_params — match the login() kwargs of the same name
+# so callers can pass them back directly on subsequent starts.
+RESOLVED_LOCATION: Final = "location"
+RESOLVED_PERMIT_MEDIA_TYPE_ID: Final = "permit_media_type_id"

--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import aiohttp
 
-from ...const import RESOLVED_LOCATION
+from ...const import RESOLVED_LOCATION, RESOLVED_PERMIT_ID
 from ...exceptions import AuthError, ProviderError, ValidationError
 from ...models import Favorite, Permit, Reservation
 from ...util import format_utc_timestamp, parse_timestamp
@@ -79,6 +79,8 @@ class Provider(BaseProvider):
     def resolved_login_params(self) -> dict[str, str]:
         """Return provider-resolved login parameters from the last successful login."""
         result: dict[str, str] = {}
+        if self._product_id is not None:
+            result[RESOLVED_PERMIT_ID] = self._product_id
         if self._product_location is not None:
             result[RESOLVED_LOCATION] = self._product_location
         return result

--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import aiohttp
 
+from ...const import RESOLVED_LOCATION
 from ...exceptions import AuthError, ProviderError, ValidationError
 from ...models import Favorite, Permit, Reservation
 from ...util import format_utc_timestamp, parse_timestamp
@@ -73,6 +74,14 @@ class Provider(BaseProvider):
         self._product_id: str | None = None
         self._product_location: str | None = None
         self._api_timezone: ZoneInfo | None = None
+
+    @property
+    def resolved_login_params(self) -> dict[str, str]:
+        """Return provider-resolved login parameters from the last successful login."""
+        result: dict[str, str] = {}
+        if self._product_location is not None:
+            result[RESOLVED_LOCATION] = self._product_location
+        return result
 
     async def login(
         self,

--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -93,7 +93,7 @@ class Provider(BaseProvider):
         merged = self._merge_credentials(credentials, **kwargs)
         username = merged.get("username")
         password = merged.get("password")
-        product_id = merged.get("permit_id")
+        product_id = merged.get("permit_id") or merged.get("product_id")
         location = merged.get("location")
 
         if not username:

--- a/src/pycityvisitorparking/provider/2park/api.py
+++ b/src/pycityvisitorparking/provider/2park/api.py
@@ -93,7 +93,7 @@ class Provider(BaseProvider):
         merged = self._merge_credentials(credentials, **kwargs)
         username = merged.get("username")
         password = merged.get("password")
-        product_id = merged.get("product_id")
+        product_id = merged.get("permit_id")
         location = merged.get("location")
 
         if not username:
@@ -119,7 +119,7 @@ class Provider(BaseProvider):
         self._product_location = location
         self._credentials = {"username": username, "password": password}
         if product_id:
-            self._credentials["product_id"] = product_id
+            self._credentials["permit_id"] = product_id
         if location:
             self._credentials["location"] = location
         self._plogger.operation_completed("login", product_id=product_id, location=location)

--- a/src/pycityvisitorparking/provider/base.py
+++ b/src/pycityvisitorparking/provider/base.py
@@ -183,6 +183,17 @@ class BaseProvider(ABC):
             reservation_update_fields=self._manifest.reservation_update_fields,
         )
 
+    @property
+    def resolved_login_params(self) -> dict[str, str]:
+        """Return provider-resolved login parameters from the last successful login.
+
+        Keys are only present when the provider discovered a value — omitted
+        when unknown. Excludes user-supplied credentials (username, password).
+        Callers may persist these and pass them back via login() kwargs on
+        subsequent starts to avoid redundant API calls.
+        """
+        return {}
+
     def _normalize_license_plate(self, plate: str) -> str:
         return normalize_license_plate(plate)
 

--- a/src/pycityvisitorparking/provider/dvsportal/api.py
+++ b/src/pycityvisitorparking/provider/dvsportal/api.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import aiohttp
 
+from ...const import RESOLVED_PERMIT_MEDIA_TYPE_ID
 from ...exceptions import AuthError, ProviderError, ValidationError
 from ...models import Favorite, Permit, Reservation
 from ...util import parse_timestamp
@@ -61,6 +62,14 @@ class Provider(BaseProvider):
         self._transport = PortalTransport(self, self._state, self._profile, self._plogger)
         self._operation_lock = asyncio.Lock()
         self._lock_owner: asyncio.Task[Any] | None = None
+
+    @property
+    def resolved_login_params(self) -> dict[str, str]:
+        """Return provider-resolved login parameters from the last successful login."""
+        result: dict[str, str] = {}
+        if self._state.permit_media_type_id is not None:
+            result[RESOLVED_PERMIT_MEDIA_TYPE_ID] = str(self._state.permit_media_type_id)
+        return result
 
     async def login(
         self,

--- a/src/pycityvisitorparking/provider/the_hague/api.py
+++ b/src/pycityvisitorparking/provider/the_hague/api.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import aiohttp
 
+from ...const import RESOLVED_PERMIT_MEDIA_TYPE_ID
 from ...exceptions import AuthError, ProviderError, ValidationError
 from ...models import BALANCE_UNIT_MINUTE, Favorite, Permit, Reservation, ZoneValidityBlock
 from ..base import BaseProvider
@@ -73,6 +74,14 @@ class Provider(BaseProvider):
         self._credentials: dict[str, str] | None = None
         self._permit_media_type_id: str | None = None
         self._logged_in = False
+
+    @property
+    def resolved_login_params(self) -> dict[str, str]:
+        """Return provider-resolved login parameters from the last successful login."""
+        result: dict[str, str] = {}
+        if self._permit_media_type_id is not None:
+            result[RESOLVED_PERMIT_MEDIA_TYPE_ID] = self._permit_media_type_id
+        return result
 
     async def login(
         self,

--- a/tests/test_2park_api.py
+++ b/tests/test_2park_api.py
@@ -204,7 +204,7 @@ async def test_login_explicit_product_id_and_location() -> None:
         credentials={
             "username": "u@e.com",
             "password": "p",
-            "product_id": "BDABZRG_1317$abc",
+            "permit_id": "BDABZRG_1317$abc",
             "location": "BDA1317",
         }
     )


### PR DESCRIPTION
## Summary

- Adds `resolved_login_params: dict[str, str]` property to `BaseProvider` (default `{}`)
- Providers override it to expose parameters discovered during login that callers can persist and pass back on subsequent starts
- **dvsportal**: exposes `permit_media_type_id`, skipping the extra GET to `_fetch_permit_media_type_id()` on every restart
- **the_hague**: exposes `permit_media_type_id` for completeness
- **2park**: exposes `location`, so `_detect_product()` (and its `CATEGORIES_ENDPOINT` call) is skipped entirely when both `product_id` and `location` are known

New providers implement `resolved_login_params` only — no changes needed in the HA integration for each new provider.

## Test plan

- [ ] All existing tests pass
- [ ] dvsportal: verify `permit_media_type_id` is returned after login
- [ ] 2park: verify `location` is returned after login
- [ ] Base class: verify default returns `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)