### PR TITLE
[codex] align release workflow with release strategy

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,11 @@ sort-direction: ascending
 
 include-paths:
   - "src/"
+  - "pyproject.toml"
+  - "README.md"
+  - "CHANGELOG.md"
+  - "LICENSE"
+  - "docs/RELEASING.md"
 
 categories:
   - title: "Breaking changes"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,8 +1,8 @@
 # Maintains a draft GitHub Release that is kept up-to-date with every push to
-# main that touches src/. The draft is populated using the rules in
-# .github/release-drafter.yml (categories, version bump strategy, etc.).
-# When a release is ready, the draft is manually published which triggers the
-# release.yml workflow to build and publish to PyPI.
+# main that touches package-shipping files. The draft is populated using the
+# rules in .github/release-drafter.yml (categories, version bump strategy,
+# etc.). When a release is ready, the draft is manually published which
+# triggers the release.yml workflow to build and publish to PyPI.
 name: Release Drafter
 # yamllint disable-line rule:truthy
 
@@ -12,6 +12,11 @@ on:
       - main
     paths:
       - "src/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "docs/RELEASING.md"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,206 @@
 # Builds and publishes the package to PyPI when a GitHub Release is published.
+# A manual dispatch can also rebuild a specific tag.
 #
 # Flow:
-#   1. Validate that the release tag matches vX.Y.Z exactly.
-#   2. Check out the exact tagged commit and verify the tag is present on HEAD.
-#   3. Build sdist + wheel, verify dist metadata with twine.
-#   4. Publish to PyPI using OIDC trusted publishing (no API token required).
+#   1. Resolve the release tag to an exact commit and verify it matches vX.Y.Z.
+#   2. Verify that the CI workflow passed on that tagged commit.
+#   3. Detect whether package-shipping files changed since the previous release.
+#   4. Build from the tagged commit, verify the artifacts, and publish to PyPI.
 #
-# Note: uv caching is disabled to prevent cache-poisoning of published artifacts.
-# Note: the release environment requires manual approval in GitHub settings.
+# Responsibility split:
+#   - release-drafter.yml prepares release drafts and notes.
+#   - ci.yml validates pull requests, main, and release tags.
+#   - This workflow publishes an already tagged and validated release.
+#
+# Note: uv caching is intentionally disabled to avoid cache-poisoning of
+# published artifacts.
+# Note: the pypi environment should require manual approval in GitHub settings.
 name: Release
 
 on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to process (e.g. v1.2.3)"
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  validate:
+    name: Check CI status
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      release_sha: ${{ steps.resolve_tag.outputs.sha }}
+      should_release: ${{ steps.package_changes.outputs.should_release }}
+      tag: ${{ steps.resolve_tag.outputs.tag }}
+    steps:
+      - name: Resolve release tag to commit
+        id: resolve_tag
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            if (!tag) {
+              core.setFailed("Missing release tag name.");
+              return;
+            }
+            if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+              core.setFailed(`Release tag must match vX.Y.Z, got: ${tag}`);
+              return;
+            }
+
+            const { data: ref } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${tag}`,
+            });
+
+            let sha = ref.object.sha;
+            if (ref.object.type === "tag") {
+              const { data: tagObject } = await github.rest.git.getTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_sha: ref.object.sha,
+              });
+              sha = tagObject.object.sha;
+            }
+
+            core.setOutput("sha", sha);
+            core.setOutput("tag", tag);
+
+      - name: Detect package changes since previous release
+        id: package_changes
+        env:
+          RELEASE_SHA: ${{ steps.resolve_tag.outputs.sha }}
+          RELEASE_TAG: ${{ steps.resolve_tag.outputs.tag }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const currentTag = process.env.RELEASE_TAG;
+            const currentSha = process.env.RELEASE_SHA;
+            const packagePaths = [
+              "src/",
+              "pyproject.toml",
+              "README.md",
+              "CHANGELOG.md",
+              "LICENSE",
+              "docs/RELEASING.md",
+            ];
+
+            async function resolveTagSha(tag) {
+              const { data: ref } = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag}`,
+              });
+
+              if (ref.object.type === "tag") {
+                const { data: tagObject } = await github.rest.git.getTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_sha: ref.object.sha,
+                });
+                return tagObject.object.sha;
+              }
+
+              return ref.object.sha;
+            }
+
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+
+            const previousRelease = releases.find(
+              (release) =>
+                !release.draft &&
+                !release.prerelease &&
+                release.tag_name !== currentTag,
+            );
+
+            if (!previousRelease) {
+              core.info("No previous published release found; proceeding with release.");
+              core.setOutput("should_release", "true");
+              return;
+            }
+
+            const previousSha = await resolveTagSha(previousRelease.tag_name);
+            const comparison = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: previousSha,
+              head: currentSha,
+            });
+
+            const changed = (comparison.data.files ?? []).some((file) =>
+              packagePaths.some(
+                (packagePath) =>
+                  file.filename === packagePath || file.filename.startsWith(packagePath),
+              ),
+            );
+
+            core.info(
+              `Previous release: ${previousRelease.tag_name}; package files changed: ${changed}`,
+            );
+            core.setOutput("should_release", changed ? "true" : "false");
+
+      - name: Verify CI workflow success
+        env:
+          RELEASE_SHA: ${{ steps.resolve_tag.outputs.sha }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const workflowName = "CI";
+            const sha = process.env.RELEASE_SHA;
+            const { data: workflows } = await github.rest.actions.listRepoWorkflows({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const workflow = workflows.workflows.find((item) => item.name === workflowName);
+            if (!workflow) {
+              core.setFailed(`Workflow not found: ${workflowName}`);
+              return;
+            }
+
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflow.id,
+              head_sha: sha,
+              per_page: 100,
+            });
+
+            const successful = runs.workflow_runs.find(
+              (run) => run.status === "completed" && run.conclusion === "success",
+            );
+            if (!successful) {
+              const summary = runs.workflow_runs
+                .map((run) => `${run.status}/${run.conclusion || "none"} (${run.html_url})`)
+                .join(", ");
+              core.setFailed(
+                `No successful CI run found for ${sha}. Runs: ${summary || "none"}`,
+              );
+            }
+
   publish:
     name: Build and publish
+    needs: [validate]
+    if: needs.validate.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -31,24 +208,11 @@ jobs:
       id-token: write # Required for trusted publishing to PyPI via GitHub OIDC.
 
     steps:
-      - name: Validate release tag
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          if [[ -z "$RELEASE_TAG" ]]; then
-            echo "Missing release tag name."
-            exit 1
-          fi
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release tag must match vX.Y.Z, got: $RELEASE_TAG"
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.validate.outputs.release_sha }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
@@ -57,7 +221,7 @@ jobs:
 
       - name: Confirm checked out tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
           if ! git tag --points-at HEAD | grep -Fx "$RELEASE_TAG" >/dev/null; then
             echo "Expected checkout to include tag $RELEASE_TAG, but it was not found on HEAD"
@@ -83,3 +247,14 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+  skip-release:
+    name: Skip publish
+    needs: [validate]
+    if: needs.validate.outputs.should_release != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip PyPI publish
+        run: |
+          echo "No package-shipping files changed since the previous published release."
+          echo "Skipping PyPI publish."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -58,15 +58,19 @@ Do not push release tags before the local checks and artifact validation pass.
    - `git push origin vX.Y.Z`
 6. Confirm the `CI` workflow passes for the tag.
 7. Publish the GitHub release for tag `vX.Y.Z`.
-8. The `Release` workflow will build from that tag and publish to PyPI using OIDC.
+8. The `Release` workflow resolves that tag to an exact commit, verifies the `CI` workflow passed on that commit, and checks whether package-shipping files changed since the previous published release.
+9. If package files changed, the workflow builds from that tagged commit and publishes to PyPI using OIDC. If not, it exits without publishing.
 
 ✅ **Understand what GitHub Actions does**
 - `CI` runs on pull requests, pushes to `main`, manual dispatch, and tags matching `v*`.
 - `Release Drafter` updates the draft release on `main` pushes and PR updates.
-- `Release` runs only when a GitHub release is published.
+- `Release` runs when a GitHub release is published and can also be run manually for an existing tag via `workflow_dispatch`.
 - The publish workflow:
-  - validates that the published release tag matches `vX.Y.Z`
-  - checks out the repository at that exact tag
+  - validates that the requested tag matches `vX.Y.Z`
+  - resolves the tag to its exact commit
+  - verifies the `CI` workflow succeeded for that commit
+  - compares the tagged commit with the previous published release and skips publishing when no package-shipping files changed
+  - checks out the repository at that exact commit
   - logs the resolved package version
   - builds `sdist` and `wheel`
   - runs `twine check`


### PR DESCRIPTION
## Summary
- align the release workflow with the Home Assistant integration release strategy
- add a validation phase that resolves the release tag, checks CI success, and detects package-shipping changes since the previous published release
- align Release Drafter so draft releases watch the same package-shipping files as the publish workflow
- document the new release behavior in `docs/RELEASING.md`

## Why
The repository already had a straightforward publish workflow, but it did not mirror the safer release gating used in the integration repo. This change keeps the release flow tag-driven while adding commit resolution, CI verification, and a no-op path when a published release would not ship any package changes.

Release Drafter also only watched `src/**`, which no longer matched the release workflow scope. Bringing those paths in line avoids draft releases lagging behind package-relevant documentation or packaging changes.

## Impact
- GitHub releases can now also be processed manually through `workflow_dispatch` with an explicit tag
- PyPI publishing is skipped when nothing release-relevant changed since the previous published release
- draft release updates now follow the same package-shipping file scope as the publish workflow
- no testing or prerelease-specific logic is introduced

## Validation
- `git diff --check`
- pre-commit hooks during `git commit`
- `pytest` via the repository commit hooks
