### PR TITLE
feat(ci): add beta pre-release support to release workflows

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -1,0 +1,67 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+committish: "main"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+no-changes-template: "- No changes in `src/` since the last release."
+exclude-labels:
+  - "skip-changelog"
+  - "duplicate"
+  - "invalid"
+exclude-contributors:
+  - "sir-Unknown"
+  - "dependabot[bot]"
+  - "renovate[bot]"
+  - "github-actions[bot]"
+  - "codex[bot]"
+  - "claude[bot]"
+sort-direction: ascending
+include-paths:
+  - "src/"
+  - "pyproject.toml"
+categories:
+  - title: "Breaking changes"
+    labels:
+      - "breaking-change"
+      - "major"
+  - title: "New features"
+    labels:
+      - "new-feature"
+      - "feature"
+  - title: "Bug fixes"
+    labels:
+      - "bugfix"
+      - "bug"
+      - "fix"
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+      - "refactor"
+      - "performance"
+      - "schema"
+      - "tests"
+  - title: "Maintenance"
+    labels:
+      - "maintenance"
+      - "ci"
+      - "github-actions"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "Dependency updates"
+    labels:
+      - "dependencies"
+template: |
+  > [!WARNING]
+  > **This is a beta pre-release.**
+  > It may contain incomplete features or minor regressions.
+  > **Use with caution in production environments.**
+
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  [![Full changelog](https://img.shields.io/badge/Full%20changelog-blue?logo=github)](https://github.com/sir-Unknown/pyCityVisitorParking/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,11 +19,6 @@ on:
       - ".github/codeql/**"
   pull_request:
     branches: [ "main" ]
-    paths:
-      - "src/**"
-      - "tests/**"
-      - ".github/workflows/**"
-      - ".github/codeql/**"
   schedule:
     - cron: '45 12 * * 1'
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,23 @@ on:
       - "CHANGELOG.md"
       - "LICENSE"
       - "docs/RELEASING.md"
+      - ".github/release-drafter.yml"
+      - ".github/release-drafter-beta.yml"
+      - ".github/workflows/release-drafter.yml"
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Release type."
+        required: false
+        default: "stable"
+        type: choice
+        options:
+          - stable
+          - beta
+      version:
+        description: "Version override (e.g. 0.5.25). Leave empty to auto-resolve from the latest stable release."
+        required: false
+        type: string
 
 permissions: {}
 
@@ -34,7 +50,47 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Run Release Drafter
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Release Drafter (stable)
+        if: inputs.prerelease == 'stable' || inputs.prerelease == ''
         uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        with:
+          version: ${{ inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next beta version
+        if: inputs.prerelease == 'beta'
+        id: next_beta_version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            BASE="${INPUT_VERSION}"
+          else
+            BASE=$(gh release list --limit 1000 --json tagName,isPrerelease \
+              --jq '[.[] | select(.isPrerelease == false) | .tagName] | first' \
+              | sed 's/^v//')
+          fi
+          LAST=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
+            | grep -E "^v${BASE}b[0-9]+$" \
+            | grep -oE "b[0-9]+" \
+            | grep -oE "[0-9]+$" \
+            | sort -n | tail -1 || true)
+          NEXT=$((${LAST:-0} + 1))
+          echo "version=${BASE}b${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Release Drafter (beta pre-release)
+        if: inputs.prerelease == 'beta'
+        uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        with:
+          config-name: release-drafter-beta.yml
+          prerelease: true
+          version: ${{ steps.next_beta_version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
               core.setFailed("Missing release tag name.");
               return;
             }
-            if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
-              core.setFailed(`Release tag must match vX.Y.Z, got: ${tag}`);
+            if (!/^v[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$/.test(tag)) {
+              core.setFailed(`Release tag must match vX.Y.Z or vX.Y.ZbN, got: ${tag}`);
               return;
             }
 


### PR DESCRIPTION
## Summary

- Adds `stable` / `beta` choice to `release-drafter.yml` `workflow_dispatch` input (default: `stable`); push triggers still work via the `|| inputs.prerelease == ''` fallback
- Auto-computes the next `bN` suffix by scanning existing release tags
- Adds `.github/release-drafter-beta.yml` config with a beta warning in the release notes
- Broadens the `release.yml` tag regex from `vX.Y.Z` to also accept `vX.Y.ZbN`

## Test plan

- [ ] Trigger `Release Drafter` workflow manually with `prerelease: beta` — verify a draft pre-release is created with the correct `vX.Y.ZbN` tag
- [ ] Trigger with `prerelease: stable` — verify normal stable draft is updated
- [ ] Push to `main` — verify stable draft is updated (push trigger path)
- [ ] Publish a `vX.Y.ZbN` release — verify `release.yml` no longer rejects the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)