### PR TITLE
fix(ci): fix sed backslash escaping in sync-python-version read step

### DIFF
--- a/.github/workflows/sync-python-version.yml
+++ b/.github/workflows/sync-python-version.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Read current Python version
         id: current
         run: |
-          MINOR=$(sed -n 's/^requires-python = \">=\\([0-9]\\+\\.[0-9]\\+\\)\"$/\\1/p' pyproject.toml)
+          MINOR=$(sed -n 's/^requires-python = ">=\([0-9]\+\.[0-9]\+\)"$/\1/p' pyproject.toml)
           if [ -z "$MINOR" ]; then
             echo "Could not read requires-python from pyproject.toml"
             exit 1


### PR DESCRIPTION
## Summary

- In YAML block scalars backslashes are literal, so `\\(` passed two backslashes to sed which tried to match a literal `\(` instead of a BRE capture group
- The `Read current Python version` step always produced an empty `MINOR` and exited 1
- Fix: use single backslashes so sed BRE receives `\(` and `\+` correctly

## Test plan

- [ ] Trigger `Sync Python version from HA Core` via workflow_dispatch and verify the `Read current Python version` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)