### PR TITLE
ci: catch stale lockfile drift before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           enable-cache: false
 
+      - name: Verify lockfile is up to date
+        run: |
+          uv lock --check
+
       - name: Lint (ruff)
         run: |
           uv run --group lint ruff check .

--- a/.github/workflows/sync-python-version.yml
+++ b/.github/workflows/sync-python-version.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Read current Python version
         id: current
         run: |
-          MINOR=$(sed -n 's/^requires-python = \">=\\([0-9]\\+\\.[0-9]\\+\\)\"$/\\1/p' pyproject.toml)
+          MINOR=$(sed -n 's/^requires-python = ">=\([0-9]\+\.[0-9]\+\)"$/\1/p' pyproject.toml)
           if [ -z "$MINOR" ]; then
             echo "Could not read requires-python from pyproject.toml"
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,6 +391,17 @@ Update docs whenever public behavior changes, especially for:
 
 ## 18) Tooling and local workflow
 
+### Branch workflow
+
+- Treat `dev` as the default working branch for day-to-day changes and small fixes.
+- Use a dedicated feature branch only for larger, clearly scoped change sets, especially when work spans multiple maintained surfaces such as library code, provider implementations, docs, packaging, or CI.
+- Do not put partial, half-reviewed, or long-running multi-commit work directly on `dev` when isolated review would be safer or clearer.
+- Keep feature branches focused on one clustered change set and do not use long-lived catch-all branches for unrelated work.
+- Feature branches SHOULD use a conventional prefix such as `feat/`, `fix/`, `refactor/`, `docs/`, `ci/`, `deps/`, `test/`, or `tests/`.
+- Do not add agent-related prefixes or suffixes such as `[codex]`, `[agent]`, or similar markers in branch names, commit titles, or pull request titles.
+- Keep feature branches current with `dev` as needed, but do not rewrite shared history once review is in progress unless explicitly requested.
+- After a feature branch is merged, delete it on GitHub and clean up the local branch as soon as it is no longer needed unless there is an explicit reason to keep it temporarily.
+
 Use `uv` for local development commands.
 
 Common commands:
@@ -433,6 +444,7 @@ Rules:
 
 - every pull request title must use one of these prefixes
 - commits should use the same title structure whenever practical
+- do not add agent-related prefixes or suffixes such as `[codex]`, `[agent]`, or similar markers in commit titles or pull request titles
 - keep titles concise and descriptive
 - align the title with the actual change scope
 - avoid vague titles such as `update stuff` or `fix issues`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,135 +1,533 @@
-# AGENT.md — Development Guide (pyCityVisitorParking)
+# AGENTS.md — Development Guide (pyCityVisitorParking)
 
-✅ **Build an async Home Assistant–friendly API library (Python 3.13)**
-- Build an async Python library that standardizes Dutch municipal “visitor parking” operations for Home Assistant.
-- Target Python 3.13 and set `requires-python = ">=3.13"`.
+## 1) Purpose
 
-✅ **Use English as the primary project language**
-- Write all documentation, comments, docstrings, commit messages, and changelogs in English.
-- Use Dutch only when quoting provider UI text or official municipality wording, and label it clearly.
+This repository contains `pycityvisitorparking`, an async Python library specifically intended to support the Home Assistant integration `city_visitor_parking`.
 
-✅ **Maintain root documentation and changelog**
-- Maintain root `README.md`.
-- Maintain root `CHANGELOG.md`.
-- Keep an “Unreleased” section and move entries into a versioned section on release.
-- Update root `CHANGELOG.md` on every release.
+The library exists to provide a small, provider-agnostic contract for:
 
-✅ **Require docstrings and clear comments**
-- Add docstrings for all public modules, classes, and methods.
-- Add clear inline comments for non-obvious logic (e.g., time/UTC conversion, normalization, fallback behavior).
-- Keep comments/docstrings free of credentials, tokens, or other PII.
+- provider discovery
+- permit lookup
+- reservation management
+- favorites management
+- normalization of provider-native API behavior into a Home Assistant-friendly generic contract
 
-✅ **Enforce project rules without exceptions**
-- Use an async-only public API.
-- Use `aiohttp` for all HTTP communication.
-- ❌ Avoid third-party provider plugins.
-- ❌ Avoid entry points.
-- Keep providers inside `src/pycityvisitorparking/provider/<provider_id>/`.
-- Allow adding a provider by changing only `provider/<provider_id>/...`.
-- Discover providers without importing provider code.
-- Keep public models strict and ❌ avoid provider-specific fields.
+The library is Home Assistant-oriented by design. Keep implementation choices, API boundaries, naming, and maintenance decisions aligned with Home Assistant developer expectations.
 
-✅ **Use the required repository layout**
-- Use `src/` layout.
-- Keep core code in `src/pycityvisitorparking/`.
-- Keep provider code in `src/pycityvisitorparking/provider/<provider_id>/`.
-- Keep `manifest.schema.json` in `src/pycityvisitorparking/provider/`.
-- Keep root `README.md` and `CHANGELOG.md` at repository root.
-- Keep per-provider `README.md` and `CHANGELOG.md` inside each provider folder.
+## 2) Current repo shape
 
-✅ **Implement the public Client facade**
-- Expose `Client` in `client.py`.
-- Implement `list_providers()` by reading manifests without importing provider modules.
-- Implement `get_provider(provider_id, ...)` by importing only the selected provider on-demand.
-- Support injecting an `aiohttp.ClientSession`.
-- ❌ Avoid closing an injected session.
-- Create an internal session only when not injected.
-- Provide `async with Client(...)` and/or `await client.aclose()` for internal cleanup.
-* Take `base_url` and `api_uri` as config inputs and pass them into providers.
-* ❌ Avoid hardcoded endpoints; keep only relative paths/constants.
+Treat this repository as five connected surfaces that must stay aligned:
 
-✅ **Define and enforce the provider interface**
-- Define `BaseProvider` in `provider/base.py`.
-- Require providers to implement standardized async methods for login, permit, reservations, and favorites.
-- Require `update_favorite()` to raise `ProviderError` when updates are not supported.
+- Python library code in `src/pycityvisitorparking/`
+- Provider implementations in `src/pycityvisitorparking/provider/<provider_id>/`
+- Public package docs such as `README.md`, `CHANGELOG.md`, and `docs/RELEASING.md`
+- Provider development docs and templates under `docs/provider-development/` and `docs/provider-template/`
+- GitHub automation for CI, release drafting, release publishing, and packaging validation
 
-✅ **Standardize time, license plates, and zone_validity**
-- Return public timestamps as UTC ISO 8601 with `Z` and without microseconds.
-- Convert provider-local/offset timestamps to UTC internally.
-- Normalize license plates to uppercase `A–Z0–9` and remove spaces/special chars.
-- Raise `ValidationError` for invalid or empty plates after normalization.
-- Filter `zone_validity` to include only chargeable windows and filter out free windows.
+Changes in one surface often require follow-up updates in the others.
 
-✅ **Keep public dataclasses strict**
-- Define public dataclasses only in `models.py`.
-- Expose only:
-  - `ProviderInfo`
-  - `Permit`
-  - `ZoneValidityBlock`
-  - `Reservation`
-  - `Favorite`
-- ❌ Avoid adding provider-specific metadata to public models.
+## 3) Core goals
 
-✅ **Enforce validation rules**
-- Require `start_time` and `end_time` for `start_reservation` and ❌ avoid defaults.
-- Enforce `end_time > start_time` and raise `ValidationError` when violated.
-- Treat IDs as opaque strings and ❌ avoid format assumptions.
-- Ensure timestamps are parseable as timezone-aware UTC datetimes.
+The library must remain:
 
-✅ **Use secure HTTP standards**
-- Enable TLS verification.
-- Enforce request timeouts.
-- Map HTTP and provider errors to custom exceptions.
-- ❌ Avoid leaking raw `aiohttp` exceptions into the public API.
-- Apply retries only to idempotent GET requests and keep defaults conservative or disabled.
+- async-only
+- provider-agnostic at the public API boundary
+- aligned with Home Assistant integration needs
+- strict about validation and error normalization
+- careful about privacy and logging
+- easy to extend with additional providers without changing the public contract unnecessarily
 
-✅ **Implement controlled errors and safe logging**
-- Define exceptions in `exceptions.py`.
-- Provide at minimum: `AuthError`, `NetworkError`, `ValidationError`, `ProviderError`.
-- ❌ Avoid including credentials, tokens, or PII in logs or exception messages.
-- Mask license plates in logs when logging is necessary.
+## 4) Runtime baseline
 
-✅ **Implement provider discovery via manifests without imports**
-- Require each provider to include `manifest.json` with `id`, `name`,
-  `capabilities.favorite_update_fields`, and `capabilities.reservation_update_fields`.
-- Read manifests using `importlib.resources` without importing provider modules.
-- Import provider modules only when selected by `get_provider()`.
+- Target Python `3.14`.
+- Keep `requires-python = ">=3.14"` aligned with:
+  - `pyproject.toml`
+  - Ruff target version
+  - Pyright version
+  - Pylint version
+  - CI configuration
+  - PyPI metadata
 
-✅ **Validate manifests via schema and fail CI on errors**
-- Add `manifest.schema.json` in `src/pycityvisitorparking/provider/`.
-- Validate every provider `manifest.json` against the schema.
-- Add a test that validates all manifests and fail CI on schema errors.
+If supported Python versions change, update all of those surfaces together.
 
-✅ **Test without live calls**
-- ❌ Avoid live municipal services in tests.
-- Use fixtures and mocked HTTP responses.
-- Add tests for normalization, UTC conversion, loader discovery, schema validation, and fallback behaviors.
+## 5) Home Assistant alignment
 
-✅ **Use Hatch for development, build, and publishing**
-- Use Hatch as the single entrypoint for dev workflows.
-- Run lint and format using Hatch environments.
-- Run tests using Hatch environments.
-- Build artifacts using `hatch build`.
-- Validate artifacts using `python -m twine check dist/*`.
+Treat Home Assistant developer guidance as the compatibility baseline for this library.
 
-✅ **Verify documentation and pinned versions and correct assumptions**
-- Check the current project documentation and the versions pinned in our lockfiles and CI.
-- Update any assumptions immediately when documentation, lockfiles, and CI disagree.
-- Align `requires-python`, Hatch environments, and CI matrices to the pinned versions.
-- Prefer the repository as the source of truth for supported versions and tooling.
-- Avoid “latest” installs in CI and keep dev tooling versions pinned.
+The library should support Home Assistant integration patterns by default:
 
-✅ **Publish releases to PyPI in a controlled way (Hatch)**
-- Bump versions using `hatch version <new>` or `hatch version <major|minor|patch>`.
-- Update root `CHANGELOG.md` and move “Unreleased” entries into the new version section.
-- Create an annotated git tag `vX.Y.Z` and push it.
-- Publish from CI on tags using trusted publishing (OIDC) when possible.
-- ❌ Avoid manual local publishing when CI publish is available.
-- Verify release contents include manifests, schema, and provider docs in `sdist`.
- - If `git push --follow-tags` is used, ensure the tag is annotated or push the tag explicitly.
+- async dependency behavior
+- injected `aiohttp.ClientSession` support
+- normalized exceptions suitable for integration-side mapping
+- generic terminology suitable for translations and user-facing HA UX
+- minimal log noise during expected retry, reauth, or temporary outage flows
 
-✅ **Apply release rules**
-- Use SemVer and keep root `CHANGELOG.md` updated.
-- Bump MINOR for provider additions.
-- Bump PATCH for bug fixes.
-- Tag releases and maintain a clear changelog history.
+If a local library convention conflicts with what is most likely to be acceptable in a Home Assistant integration dependency, resolve the conflict in favor of the Home Assistant-friendly option.
+
+## 6) Provider boundary
+
+All provider-native API behavior must be implemented inside `pycityvisitorparking`.
+
+This includes:
+
+- authentication quirks
+- endpoint structure
+- request and response parsing
+- municipality-specific payload handling
+- provider-specific fallback behavior
+- native identifiers, temporary tokens, and intermediate fields required only for provider communication
+- provider-specific availability, balance, permit, reservation, and favorite mapping
+- normalization of provider-native concepts into the generic public contract
+
+The Home Assistant integration must not become the place where provider quirks are implemented.
+
+If behavior is specific to one provider, municipality, backend, or API implementation, it belongs in the library.
+
+## 7) User-facing contract
+
+Anything shown to users must remain generic.
+
+This applies to:
+
+- config flow text
+- options flow text
+- reauthentication text
+- entity names
+- entity attributes intended for users
+- service names and service fields
+- service validation errors
+- diagnostics summaries
+- websocket payloads exposed to the frontend
+- frontend labels, messages, actions, and errors
+- documentation aimed at end users
+
+Do not expose provider-native terminology, raw provider field names, municipality-specific backend wording, or API-specific concepts to users unless they have first been normalized into a generic library concept.
+
+## 8) Public API contract
+
+The public API is intentionally small and stable.
+
+### Client
+
+`Client` in `src/pycityvisitorparking/client.py` is the public entry point.
+
+It must:
+
+- support async provider discovery with `list_providers()`
+- support lazy provider loading with `get_provider(provider_id, ...)`
+- accept an optional injected `aiohttp.ClientSession`
+- create and own an internal session only when no session is injected
+- never close an injected session
+- support `async with Client(...)`
+- support explicit cleanup with `await client.aclose()`
+
+### Provider loading
+
+Provider discovery must:
+
+- load provider manifests without importing all provider modules
+- import only the selected provider module when `get_provider()` is called
+- validate manifest structure and values
+- keep discovery logic in the loader, not in the integration layer
+
+### Public models
+
+Public dataclasses must live in `src/pycityvisitorparking/models.py`.
+
+Current public models are:
+
+- `ProviderInfo`
+- `Permit`
+- `ZoneValidityBlock`
+- `Reservation`
+- `Favorite`
+
+Keep the models provider-agnostic.
+
+Current model expectations:
+
+- `ProviderInfo` exposes:
+  - `id`
+  - `favorite_update_fields`
+  - `reservation_update_fields`
+  - `balance_units`
+- `Permit` exposes:
+  - `id`
+  - `remaining_balance`
+  - `zone_validity`
+  - `balance_unit`
+- `ZoneValidityBlock` exposes:
+  - `start_time`
+  - `end_time`
+- `Reservation` exposes:
+  - `id`
+  - `name`
+  - `license_plate`
+  - `start_time`
+  - `end_time`
+- `Favorite` exposes:
+  - `id`
+  - `name`
+  - `license_plate`
+
+Do not add provider-specific metadata to these public models unless the field is generic across providers and justified by multiple real implementations.
+
+## 9) Public API anti-leak rule
+
+Do not expose provider-native details through the public library surface unless they have been normalized into a generic concept.
+
+In particular:
+
+- avoid exporting provider-specific constants from `pycityvisitorparking.__init__`
+- avoid making provider-specific login resolution details part of the public contract
+- avoid requiring the integration to understand provider-native field names
+- avoid forcing the integration to persist provider-native state unless there is a generic contract for it
+
+If a piece of data only exists to talk to a specific provider API, it should stay internal to the provider implementation unless and until it is promoted into a generic library concept.
+
+## 10) Base provider contract
+
+`BaseProvider` in `src/pycityvisitorparking/provider/base.py` defines the shared provider behavior.
+
+Providers must follow the current base contract and shared helpers for:
+
+- authentication flow
+- request building
+- timeout handling
+- retry behavior
+- reservation time validation
+- UTC normalization
+- license plate normalization
+- chargeable `zone_validity` filtering
+- normalized exceptions
+- structured logging
+
+Provider implementations should reuse base helpers instead of duplicating validation or normalization logic.
+
+## 11) Time, balance, and identifier rules
+
+### Timestamps
+
+- Return public timestamps as UTC ISO 8601 strings.
+- Keep them timezone-aware and normalized.
+- Do not expose raw provider-local timestamps in the public API.
+
+### Zone validity
+
+- Public `zone_validity` must contain chargeable windows only.
+- Free windows must be filtered out before public exposure.
+- Invalid or ambiguous provider time data must raise normalized library errors rather than leaking raw parsing failures.
+
+### Reservation times
+
+- `start_reservation` requires both `start_time` and `end_time`.
+- Enforce `end_time > start_time`.
+- Treat update operations separately from create operations; partial updates are allowed only when the provider contract supports them.
+
+### License plates
+
+- Normalize license plates consistently.
+- Validate inputs strictly.
+- Raise `ValidationError` for invalid or empty values after normalization.
+- Never log full license plates when avoidable.
+
+### IDs
+
+- Treat provider IDs, permit IDs, reservation IDs, and favorite IDs as opaque strings.
+- Do not make format assumptions unless strictly required by that provider internally.
+
+### Balance
+
+- Support generic balance reporting through:
+  - `remaining_balance`
+  - `balance_unit`
+  - `balance_units`
+- Restrict balance units to the supported generic set defined by the library.
+
+## 12) Error handling
+
+All public errors must be normalized through `src/pycityvisitorparking/exceptions.py`.
+
+Current exception hierarchy includes at least:
+
+- `PyCityVisitorParkingError`
+- `AuthError`
+- `NetworkError`
+- `ValidationError`
+- `ProviderError`
+- `RateLimitError`
+- `ServiceUnavailableError`
+- `NotFoundError`
+- `TimeoutError`
+- `ConfigError`
+
+### Rules
+
+- Do not leak raw `aiohttp` exceptions through the public API.
+- Prefer mapping network and provider failures to the library exception hierarchy.
+- Preserve safe metadata when useful:
+  - `error_code`
+  - `detail`
+- Keep exception messages technical and integration-facing, not end-user-facing.
+- Do not rely on library exception text as user-facing copy.
+- Keep exception messages free of credentials, tokens, and PII.
+
+## 13) Logging and privacy
+
+The library must be safe to use in Home Assistant environments with sensitive user data.
+
+### Never log
+
+- passwords
+- tokens
+- raw credentials
+- full license plates
+- raw provider payloads containing PII unless explicitly redacted
+
+### Do log carefully
+
+- provider id
+- request context
+- normalized error types
+- safe runtime version information
+- safe diagnostics helpful for debugging provider behavior
+
+### Logging behavior
+
+- avoid warning-level noise for expected retry paths
+- avoid warning-level noise for expected reauthentication paths
+- prefer debug logging for routine transport failures that the integration will recover from
+- reserve warning and error logs for truly unexpected or actionable situations
+
+Use the provider logger infrastructure instead of ad-hoc logging patterns.
+
+## 14) Provider manifests
+
+Each provider must include `manifest.json` in its provider folder.
+
+Current manifest expectations include:
+
+- `id`
+- `name`
+- `capabilities.favorite_update_fields`
+- `capabilities.reservation_update_fields`
+- optional `capabilities.balance_units`
+
+### Rules
+
+- Manifest `id` must match the provider folder name.
+- Manifest values must be validated against the supported schema and allowed values.
+- Discovery must read manifests via `importlib.resources`.
+- Manifest loading must not require importing every provider module.
+- Keep manifest loading and cache behavior in the loader layer.
+
+## 15) Loader and cache behavior
+
+Provider discovery currently uses a loader/cache layer.
+
+Maintain these principles:
+
+- manifest loading is centralized in `provider/loader.py`
+- cache behavior is explicit and testable
+- cache invalidation is available for tests
+- async wrappers exist for blocking loader operations
+- loader errors surface as normalized library errors
+
+When changing loader behavior, update tests for:
+
+- discovery
+- cache hit/miss behavior
+- refresh behavior
+- schema validation
+- provider lookup failures
+
+## 16) Repository layout
+
+Keep the repository aligned with the current layout:
+
+- root docs:
+  - `README.md`
+  - `CHANGELOG.md`
+  - `AGENTS.md`
+  - `SECURITY.md`
+  - `docs/RELEASING.md`
+- source package:
+  - `src/pycityvisitorparking/`
+- provider root:
+  - `src/pycityvisitorparking/provider/`
+- provider-specific docs:
+  - `README.md`
+  - `CHANGELOG.md`
+  - optional provider-specific `AGENTS.md`
+- provider docs and templates:
+  - `docs/provider-development/`
+  - `docs/provider-template/`
+
+Do not introduce alternate layouts without a strong reason.
+
+## 17) Documentation policy
+
+Use English as the primary project language.
+
+Maintain these docs as part of the product surface:
+
+- root `README.md`
+- root `CHANGELOG.md`
+- `docs/RELEASING.md`
+- provider `README.md`
+- provider `CHANGELOG.md`
+- provider development docs and templates when provider authoring changes
+
+Update docs whenever public behavior changes, especially for:
+
+- new providers
+- auth flow changes
+- request parameter changes
+- manifest changes
+- public model changes
+- exception behavior changes
+- release flow changes
+- Home Assistant integration boundary changes
+
+## 18) Tooling and local workflow
+
+Use `uv` for local development commands.
+
+Common commands:
+
+- `uv run --group lint ruff check .`
+- `uv run --group lint ruff format --check .`
+- `uv run --group typecheck pyright`
+- `uv run --group test pytest`
+- `uv run --group schema python -m pytest -o addopts=-q tests/test_manifest_schema.py`
+- `uv build`
+- `uvx twine check dist/*`
+
+### Build backend
+
+The project uses:
+
+- `hatchling` as the build backend
+- `hatch-vcs` for version derivation from git tags
+
+That does not change the local developer workflow rule: use `uv` for development tasks.
+
+## 19) Commit and PR titles
+
+Commits and pull requests must use the repository title convention.
+
+Use a recognized conventional prefix such as:
+
+- `feat:`
+- `fix:`
+- `docs:`
+- `chore:`
+- `refactor:`
+- `perf:`
+- `ci:`
+- `deps:`
+- `test:`
+- `tests:`
+
+Rules:
+
+- every pull request title must use one of these prefixes
+- commits should use the same title structure whenever practical
+- keep titles concise and descriptive
+- align the title with the actual change scope
+- avoid vague titles such as `update stuff` or `fix issues`
+
+This convention is required for CI labeling, release categorization, and changelog automation.
+
+## 20) Versioning and releases
+
+### Source of truth
+
+The package version is derived from git tags through `hatch-vcs`.
+
+Hard rules:
+
+- do not manually edit a version string for releases
+- use release tags matching `vX.Y.Z`
+- keep changelogs aligned with the released version
+- publish GitHub releases from the intended tag
+
+### Release process
+
+Before release:
+
+- update docs and changelogs
+- run local validation
+- build artifacts
+- run `twine check`
+
+Release flow:
+
+1. Commit the release changes.
+2. Create an annotated tag `vX.Y.Z`.
+3. Push the commit and tag.
+4. Confirm CI passes for the tag.
+5. Publish the GitHub release for that tag.
+6. Let the release workflow publish to PyPI when package-shipping files changed.
+
+Keep this aligned with `docs/RELEASING.md` and GitHub Actions workflows.
+
+## 21) Testing policy
+
+Tests must not call live municipal services.
+
+Use mocked or stubbed behavior for:
+
+- HTTP requests
+- provider responses
+- manifest loading
+- loader cache behavior
+- exceptions
+- fallback behavior
+
+Minimum expected coverage includes:
+
+- client session ownership
+- provider discovery
+- lazy provider loading
+- manifest schema validation
+- time normalization
+- license plate normalization
+- exception mapping
+- reservation validation
+- favorites behavior
+- fallback behavior
+- provider-specific mapping tests where relevant
+- integration-boundary regression risks when public fields or errors change
+
+When changing shared behavior, update shared tests first.
+When changing provider-specific behavior, update provider tests and provider docs together.
+
+## 22) Adding or changing providers
+
+A provider addition or major provider change must keep the repository consistent.
+
+Expected updates usually include:
+
+- provider implementation code
+- `manifest.json`
+- provider `README.md`
+- provider `CHANGELOG.md`
+- provider tests
+- root docs when public behavior changes
+
+If a provider has unique development or maintenance rules, add a provider-specific `AGENTS.md` in that provider folder.
+
+## 23) Change discipline
+
+When making changes:
+
+- keep the public contract generic
+- keep provider quirks local
+- keep async and session ownership correct
+- keep docs and tests in sync
+- keep packaging and release behavior correct
+- keep privacy guarantees intact
+- keep the Home Assistant integration boundary clear
+
+If a proposed change conflicts with those priorities, prefer the option that preserves a stable, provider-agnostic, Home Assistant-friendly library contract.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,84 @@
-# pyCityVisitorParking
+<h1 align="center">
+  pyCityVisitorParking
+  <br>
+  <sub><span style="font-size: 0.7em;">Async Python library for Dutch municipal visitor parking providers</span></sub>
+</h1>
 
-[![PyPI version](https://img.shields.io/pypi/v/pycityvisitorparking)](https://pypi.org/project/pycityvisitorparking/)
-[![Python versions](https://img.shields.io/pypi/pyversions/pycityvisitorparking)](https://pypi.org/project/pycityvisitorparking/)
-[![CI](https://github.com/sir-Unknown/pyCityVisitorParking/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sir-Unknown/pyCityVisitorParking/actions/workflows/ci.yml)
+<p align="center">
+  Provider-agnostic async Python library for Dutch municipal visitor parking systems.
+  <br>
+  Designed for Home Assistant, but usable in any async Python application.
+</p>
 
-Async Python library for Dutch municipal visitor parking providers.
+<p align="center">
+  <a href="https://pypi.org/project/pycityvisitorparking/">
+    <img src="https://img.shields.io/pypi/v/pycityvisitorparking" alt="PyPI version">
+  </a>
+  <a href="https://pypi.org/project/pycityvisitorparking/">
+    <img src="https://img.shields.io/pypi/pyversions/pycityvisitorparking" alt="Python versions">
+  </a>
+  <a href="https://github.com/sir-Unknown/pyCityVisitorParking/actions/workflows/ci.yml">
+    <img src="https://github.com/sir-Unknown/pyCityVisitorParking/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI">
+  </a>
+</p>
 
-The library exposes a small provider-agnostic API for:
+> [!TIP]
+> Looking for the Home Assistant integration? See: [ha_City-Visitor-Parking](https://github.com/sir-Unknown/ha_City-Visitor-Parking)
+
+---
+
+## About this library
+
+**pyCityVisitorParking** is an async Python library for Dutch municipal visitor parking providers.
+
+It exposes a small provider-agnostic API for:
+
 - provider discovery
 - permit lookup
 - reservation management
 - favorites management
 
-It is designed for Home Assistant use, but can also be used directly in any async Python application.
+The library is designed primarily for Home Assistant use, but it can also be used directly in any async Python application.
+
+---
 
 ## Status
 
-Current bundled providers:
+Currently bundled providers:
+
 - DVS Portal
 - The Hague
 - 2park
 
 Provider manifests are discovered from `src/pycityvisitorparking/provider/` without importing all providers up front.
 
-Provider documentation:
-- DVS Portal: <https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/dvsportal/README.md>
-- The Hague: <https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/the_hague/README.md>
-- 2park: <https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/2park/README.md>
+Provider-specific documentation:
+
+- [DVS Portal](https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/dvsportal/README.md)
+- [The Hague](https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/the_hague/README.md)
+- [2park](https://github.com/sir-Unknown/pyCityVisitorParking/blob/main/src/pycityvisitorparking/provider/2park/README.md)
+
+---
 
 ## Supported municipalities
 
 For the exact `base_url`, `api_uri`, and provider-specific notes, see the provider README files.
 
-- DVS Portal: Apeldoorn, Bloemendaal, Delft, Den Bosch, Doetinchem (via Buha), Groningen, Haarlem, Harlingen, Heemstede, Heerenveen, Heerlen, Hengelo, Katwijk, Leiden, Leidschendam-Voorburg, Middelburg, Nissewaard, Oldenzaal, Rijswijk, Roermond, Schouwen-Duiveland, Sittard-Geleen, Smallingerland, Sudwest-Fryslan, Veere, Venlo, Vlissingen, Waadhoeke, Waalwijk, Weert, Zaanstad, Zevenaar, Zutphen, Zwolle
-- The Hague: The Hague
-- 2park: Amstelveen, Assen, Bergen op Zoom, Breda, Deventer, Dordrecht, Eindhoven, Emmen, Etten-Leur, Gorinchem, Hardenberg, Harderwijk, Maastricht, Oosterhout, Oss, Roosendaal, Sluis, Terneuzen, Tiel, Veenendaal, Vlaardingen
+- **DVS Portal**: Apeldoorn, Bloemendaal, Delft, Den Bosch, Doetinchem (via Buha), Groningen, Haarlem, Harlingen, Heemstede, Heerenveen, Heerlen, Hengelo, Katwijk, Leiden, Leidschendam-Voorburg, Middelburg, Nissewaard, Oldenzaal, Rijswijk, Roermond, Schouwen-Duiveland, Sittard-Geleen, Smallingerland, Sudwest-Fryslan, Veere, Venlo, Vlissingen, Waadhoeke, Waalwijk, Weert, Zaanstad, Zevenaar, Zutphen, Zwolle
+- **The Hague**: The Hague
+- **2park**: Amstelveen, Assen, Bergen op Zoom, Breda, Deventer, Dordrecht, Eindhoven, Emmen, Etten-Leur, Gorinchem, Hardenberg, Harderwijk, Maastricht, Oosterhout, Oss, Roosendaal, Sluis, Terneuzen, Tiel, Veenendaal, Vlaardingen
 
-The 2park list is non-exhaustive. Check <https://mijn.2park.nl> for the current provider coverage.
+---
 
 ## Installation
 
-Requires Python 3.14 or newer.
+Requires **Python 3.14** or newer.
 
 ```bash
 pip install pycityvisitorparking
 ```
+
+---
 
 ## Quickstart
 
@@ -69,18 +103,21 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+---
+
 ## Public API
 
 ### Client
 
 `Client` is the main entry point.
 
-- `list_providers()` returns available `ProviderInfo` objects.
-- `get_provider(provider_id, ...)` loads a specific provider on demand.
-- `Client` accepts an optional injected `aiohttp.ClientSession`.
-- If you do not inject a session, the client creates and owns its own session.
+- `list_providers()` returns available `ProviderInfo` objects
+- `get_provider(provider_id, ...)` loads a specific provider on demand
+- `Client` accepts an optional injected `aiohttp.ClientSession`
+- if you do not inject a session, the client creates and owns its own session
 
 Configuration options:
+
 - `base_url`: provider base URL
 - `api_uri`: optional provider API path
 - `timeout`: optional `aiohttp.ClientTimeout`
@@ -88,7 +125,8 @@ Configuration options:
 
 ### Data models
 
-The public data models are:
+Public data models:
+
 - `ProviderInfo`
 - `Permit`
 - `ZoneValidityBlock`
@@ -96,6 +134,7 @@ The public data models are:
 - `Favorite`
 
 Model highlights:
+
 - `ProviderInfo` includes `id`, `favorite_update_fields`, `reservation_update_fields`, and `balance_units`
 - `Permit` includes `id`, `remaining_balance`, `balance_unit`, and `zone_validity`
 - `ZoneValidityBlock` contains UTC ISO 8601 `start_time` and `end_time`
@@ -104,14 +143,16 @@ Model highlights:
 
 ### Standardized behavior
 
-- Timestamps are returned as UTC ISO 8601 strings.
-- License plates are normalized and validated.
-- The public API stays provider-agnostic.
-- Some update operations may be unsupported by a provider; inspect `favorite_update_fields` and `reservation_update_fields`.
+- timestamps are returned as UTC ISO 8601 strings
+- license plates are normalized and validated
+- the public API stays provider-agnostic
+- some update operations may be unsupported by a provider; inspect `favorite_update_fields` and `reservation_update_fields`
+
+---
 
 ## Common usage
 
-List providers:
+### List providers
 
 ```python
 import asyncio
@@ -128,7 +169,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Manage a reservation:
+### Manage a reservation
 
 ```python
 import asyncio
@@ -158,7 +199,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Manage favorites:
+### Manage favorites
 
 ```python
 import asyncio
@@ -183,6 +224,8 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+---
 
 ## Error handling
 
@@ -219,6 +262,8 @@ async with Client(base_url=base_url, api_uri=api_uri) as client:
         handle_provider_issue(exc)
 ```
 
+---
+
 ## Logging
 
 The library logs to the `pycityvisitorparking` logger using the standard Python `logging` module.
@@ -226,6 +271,8 @@ The library logs to the `pycityvisitorparking` logger using the standard Python 
 - credentials are not logged
 - full license plates are not logged
 - request context can be attached for clearer diagnostics
+
+---
 
 ## Development
 
@@ -245,9 +292,15 @@ uvx twine check dist/*
 
 Release notes and publishing are handled through GitHub Actions. See [docs/RELEASING.md](docs/RELEASING.md).
 
+---
+
 ## Provider development
 
-Providers live under `src/pycityvisitorparking/provider/<provider_id>/`.
+Providers live under:
+
+```text
+src/pycityvisitorparking/provider/<provider_id>/
+```
 
 A provider folder typically contains:
 
@@ -261,10 +314,13 @@ src/pycityvisitorparking/provider/<provider_id>/
   CHANGELOG.md
 ```
 
-Related docs:
-- Provider framework: [src/pycityvisitorparking/provider/README.md](src/pycityvisitorparking/provider/README.md)
-- Provider template: [docs/provider-template/README.md](docs/provider-template/README.md)
-- Provider development guide: [docs/provider-development/README.md](docs/provider-development/README.md)
+Related documentation:
+
+- [Provider framework](src/pycityvisitorparking/provider/README.md)
+- [Provider template](docs/provider-template/README.md)
+- [Provider development guide](docs/provider-development/README.md)
+
+---
 
 ## License
 

--- a/uv.lock
+++ b/uv.lock
@@ -479,19 +479,19 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
-    { name = "ruff", specifier = "==0.15.10" },
-    { name = "zizmor", specifier = "==1.23.1" },
+    { name = "ruff", specifier = "==0.15.11" },
+    { name = "zizmor", specifier = "==1.24.0" },
 ]
 lint = [
     { name = "pylint", specifier = "==4.0.5" },
-    { name = "ruff", specifier = "==0.15.10" },
+    { name = "ruff", specifier = "==0.15.11" },
 ]
 schema = [
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
 ]
-security = [{ name = "zizmor", specifier = "==1.23.1" }]
+security = [{ name = "zizmor", specifier = "==1.24.0" }]
 test = [
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "pytest", specifier = "==9.0.3" },
@@ -676,27 +676,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.10"
+version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]
@@ -784,18 +784,18 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.23.1"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/58/d0228b1332f001f905d3cdd288a878d339e740ef8a92c321696a7359bdcd/zizmor-1.23.1.tar.gz", hash = "sha256:eb9871f1de004d8c6e35ff403bd6a41c495062736e78b9c4a98988970c598639", size = 463942, upload-time = "2026-03-08T16:57:29.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/74/b20bae07a1ea4423f8b1bd5be0b4a0229885573d5aa0f9f8cb5c8a7af8ae/zizmor-1.24.0.tar.gz", hash = "sha256:be338442c90d072f6fe74737793b92f2dd8350ba2aefcde157ae77d53e322a47", size = 501277, upload-time = "2026-04-13T02:22:13.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/57/32893d3370aa39f140934ee346a77aff1bc38d1de5248b9385dfcea612b7/zizmor-1.23.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:85f222eb610379aeeea76e4dc616621fdae9f21db77d1b006820452cafa739eb", size = 9085239, upload-time = "2026-03-08T16:57:32.241Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/43/037b68a2d173a44286f27c5c47e219d8beba758a323e1642770956831732/zizmor-1.23.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:82a7925bbdbc69713cbeb19ec90012cba3b92e3ace65ae60088e9604c5724182", size = 8657180, upload-time = "2026-03-08T16:57:23.078Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/37/322ec0e8b8d39a7de30290b754bd564c0b1c432d72f7b7aa011eca87cc7b/zizmor-1.23.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:19af913bb4bcd6dfeea41477fcf203d69e053f4b14a2b35690485c44ffa6c4a7", size = 8788247, upload-time = "2026-03-08T16:57:18.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e7/5ca6f7d56741b190c6d7d3721eb98c66e23fb68d64e6886c92993e049f36/zizmor-1.23.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:08ae0d8f4d665f6cf9b475913c64d2193d52ffc6f02ce66d4dcfd1b92daf4f82", size = 8374212, upload-time = "2026-03-08T16:57:25.437Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/a5/a3784392aeaca14d65c5e5efa2795d887ba24db4871a942e06a99f90a3c8/zizmor-1.23.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:08233d0d25947e43ac92374f22383c04e43f351f44bc44d60b3c0695157c0f3e", size = 9230697, upload-time = "2026-03-08T16:57:34.425Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/0d/4475ded1664262af70525700e158c3156653391770159d65cd80245fb68e/zizmor-1.23.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:795e04dff47ca1d1b0af2d7a5d3a96909a18d5fa80548534951efb24af6ec83e", size = 8820009, upload-time = "2026-03-08T16:57:36.865Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/818c68d9b407e3d02fbe7e39ad73750846d19afad50c4c9ad86455214fc2/zizmor-1.23.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:c62059c75100d0bc1a19cd95a6dce9b93ac5ab2e7d7bcdd974c51b2c5eb503e3", size = 8331336, upload-time = "2026-03-08T16:57:20.825Z" },
-    { url = "https://files.pythonhosted.org/packages/28/bb/1c984e1474fcf5f08e5847838007668d2682e1fcbc109d481967736ab18f/zizmor-1.23.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cf0dc93171e9ae7b822041471715ea7a9f5ebefa6865ceb6d1a39729a982d770", size = 9314682, upload-time = "2026-03-08T16:57:27.361Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/26/10f597f9b19ecd7bece2a1eb7d1ca1bd09d089d750d70365c76118056ec1/zizmor-1.23.1-py3-none-win32.whl", hash = "sha256:229c6b275941a18b03eef0ba5d24089dfbbe4fc34633a6b22bf924294ef69cde", size = 7464678, upload-time = "2026-03-08T16:57:30.569Z" },
-    { url = "https://files.pythonhosted.org/packages/04/25/14071ea8ab5ebde85391d27e9de060d8a31a44eea448aba8d8bdd30693b3/zizmor-1.23.1-py3-none-win_amd64.whl", hash = "sha256:dc9befe3c08fea7d0fa3a0bc98073fadf31a77f0572b1f7931e1ff300337fe11", size = 8506938, upload-time = "2026-03-08T16:57:15.787Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ca/a230a9402e60b12d0aa7ebf8284b436913e7585715cd0fb56801a73e395b/zizmor-1.24.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:824b98085b3b36e39a878a2c3fbd29957ea4ef96d1933d78bfe67c4f303e0817", size = 9118080, upload-time = "2026-04-13T02:22:19.302Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2a/8a4a5c6e3a2fa88f562a75a1d521c162ec3c0a8519432e8868114af5770d/zizmor-1.24.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e06309df31d3b80014d3e25bdece3c973e53d585c2ed5f37a7505a50b6a575e4", size = 8665212, upload-time = "2026-04-13T02:22:03.91Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ee/3bc390a11673db042c4e0610f6603a262fbcede7fb678ed2a9d9fb2a79a0/zizmor-1.24.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:b2e03041150c9f62dfd1ff95d93b75dc3e3ca13356563d7fc4bf52119e84df44", size = 8837475, upload-time = "2026-04-13T02:22:21.173Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b3/b8aaa403e484c739e96c141282fe1177a48b751b4a959dc85801d81159e4/zizmor-1.24.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:325b4ed490bad73c9d36b9987e0e306e86219caa2b1f80ee3dccd5c708ff5067", size = 8429752, upload-time = "2026-04-13T02:22:15.2Z" },
+    { url = "https://files.pythonhosted.org/packages/10/79/787412bf2f8761501ae0aaa72758114adfef7475573cb6b8e73939a7832e/zizmor-1.24.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f6364dae78f3b8ed8ed567e5b804ff14a0572f3afab885210eb749eef925f447", size = 9265384, upload-time = "2026-04-13T02:22:09.597Z" },
+    { url = "https://files.pythonhosted.org/packages/90/47/264d6cb547471446510b90cbf79e9ac4fac0cc6fac571728bb258acc19e5/zizmor-1.24.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9799ac5683fbee1dc5ba7422329b8c6e7dcdf92c2e2ff8018f1a6890403530bc", size = 8861830, upload-time = "2026-04-13T02:22:17.253Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/2f12540803aeb9d2d4b8ac3965b6d927e949b1d1ed7b51a389560134d77f/zizmor-1.24.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b89ecb43dcf66225ad1e1399c60d723d15da8372bfae55a774a55e249332165a", size = 8383365, upload-time = "2026-04-13T02:22:07.575Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7a/23ff4a4b8e7cb261104d19fef0c8e0aff669a75b918fce8ad7d7157d4e42/zizmor-1.24.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7b101b61878e6bd61f6e2a523d3b037b66cff62e9221fa6426992d1927ed7af5", size = 9353911, upload-time = "2026-04-13T02:22:11.982Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/12/7435965b9d8337f611decea3ff385d7d9e4be25b9637a76c27ccca49899d/zizmor-1.24.0-py3-none-win32.whl", hash = "sha256:7c50553784d9a7ee00f78d7818b96639ed2647a1639ac30b2bfe459357216c50", size = 7503187, upload-time = "2026-04-13T02:22:05.93Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9c/27f44865994ad518aac7ef765804507ca99110822c6308449a262ee92289/zizmor-1.24.0-py3-none-win_amd64.whl", hash = "sha256:df4b1c224f6eeb2b95aa30a2213d2f0ce8ef5430e90724c4b1d0cc6887ce8997", size = 8540312, upload-time = "2026-04-13T02:22:01.812Z" },
 ]


### PR DESCRIPTION
## Summary
- add a CI guard that runs `uv lock --check` before lint, type checking, tests, and build
- refresh `uv.lock` so the repository matches the declared dependency metadata again
- catch stale package metadata drift during regular CI instead of during the release publish workflow

## Why
The April 20, 2026 `Release` workflow for tag `v0.5.25` failed in the `Build and publish` job because `uv run --locked ...` detected that `uv.lock` was stale. In this repo, `README.md` is part of package metadata, so docs-only changes can still invalidate the lockfile.

## Impact
This makes the failure show up on PRs and branch CI before a release tag is published, reducing release-time surprises and making the fix path clearer.

## Validation
- `uv lock --check`
- pre-commit hooks during commit
  - `pyright`
  - `pytest`
  - `zizmor`
  - `yamllint`
  - `codespell` was skipped for this commit because it false-positives on the valid dependency name `astroid` in generated `uv.lock`
